### PR TITLE
Add release dates to changelog

### DIFF
--- a/releasetool/commands/start/java.py
+++ b/releasetool/commands/start/java.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+import datetime
 import getpass
 import os
 import textwrap
@@ -22,6 +22,7 @@ from glob import glob
 import attr
 import click
 import re
+from pytz import timezone
 
 import releasetool.filehelpers
 import releasetool.git
@@ -102,7 +103,12 @@ def gather_changes(ctx: Context) -> None:
 
 def edit_release_notes(ctx: Context) -> None:
     click.secho(f"> Opening your editor to finalize release notes.", fg="cyan")
-    release_notes = "\n".join(f"- {change}" for change in ctx.changes)
+    release_notes = (
+        datetime.datetime.now(datetime.timezone.utc)
+        .astimezone(timezone("US/Pacific"))
+        .strftime("%m-%d-%Y %H:%M %Z\n\n")
+    )
+    release_notes += "\n".join(f"- {change}" for change in ctx.changes)
     release_notes += "\n\n### ".join(
         [
             "",

--- a/releasetool/commands/start/nodejs.py
+++ b/releasetool/commands/start/nodejs.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
 import getpass
 import os
 import textwrap
@@ -19,6 +20,7 @@ from typing import Optional, Sequence
 
 import attr
 import click
+from pytz import timezone
 
 import releasetool.filehelpers
 import releasetool.git
@@ -93,7 +95,13 @@ def gather_changes(ctx: Context) -> None:
 
 def edit_release_notes(ctx: Context) -> None:
     click.secho(f"> Opening your editor to finalize release notes.", fg="cyan")
-    release_notes = "\n".join(f"- {change}" for change in ctx.changes)
+    release_notes = (
+        datetime.datetime.now(datetime.timezone.utc)
+        .astimezone(timezone("US/Pacific"))
+        .strftime("%m-%d-%Y %H:%M %Z\n\n")
+    )
+
+    release_notes += "\n".join(f"- {change}" for change in ctx.changes)
     release_notes += "\n\n### ".join(
         [
             "",
@@ -190,11 +198,7 @@ def create_release_commit(ctx: Context) -> None:
     """Create a release commit."""
     click.secho("> Committing changes", fg="cyan")
     releasetool.git.commit(
-        [
-            "CHANGELOG.md",
-            "package.json",
-            "samples/package.json"
-        ],
+        ["CHANGELOG.md", "package.json", "samples/package.json"],
         f"Release v{ctx.release_version}",
     )
 

--- a/releasetool/commands/start/python.py
+++ b/releasetool/commands/start/python.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
 import getpass
 import os
 import textwrap
@@ -19,6 +20,7 @@ from typing import Optional, Sequence
 
 import attr
 import click
+from pytz import timezone
 
 import releasetool.filehelpers
 import releasetool.git
@@ -97,7 +99,12 @@ def gather_changes(ctx: Context) -> None:
 
 def edit_release_notes(ctx: Context) -> None:
     click.secho(f"> Opening your editor to finalize release notes.", fg="cyan")
-    release_notes = "\n".join(f"- {change}" for change in ctx.changes)
+    release_notes = (
+        datetime.datetime.now(datetime.timezone.utc)
+        .astimezone(timezone("US/Pacific"))
+        .strftime("%m-%d-%Y %H:%M %Z\n\n")
+    )
+    release_notes += "\n".join(f"- {change}" for change in ctx.changes)
     release_notes += "\n\n### ".join(
         [
             "",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ dependencies = [
     "attrs",
     "click",
     "keyring",
-    "packaging"
+    "packaging",
+    "pytz",
 ]
 
 packages = setuptools.find_packages()


### PR DESCRIPTION
Adding the date of the release as the first line of the changelog. See #54. 

<br>

## 0.8.0
09-21-2018 11:15 PDT

### Implementation Changes
- make release.sh executable ([#50](https://github.com/GoogleCloudPlatform/releasetool/pull/50))

### New Features
- Add link to Kokoro release job for python tools ([#55](https://github.com/GoogleCloudPlatform/releasetool/pull/55))

### Documentation
- Update instructions to be more clear ([#51](https://github.com/GoogleCloudPlatform/releasetool/pull/51))

