### PR TITLE
Fix Ruby start

### DIFF
--- a/releasetool/commands/start/ruby.py
+++ b/releasetool/commands/start/ruby.py
@@ -22,7 +22,6 @@ import attr
 import click
 import datetime
 import glob
-from pytz import timezone
 
 import releasetool.filehelpers
 import releasetool.git
@@ -89,12 +88,7 @@ def gather_changes(ctx: Context) -> None:
 
 def edit_release_notes(ctx: Context) -> None:
     click.secho(f"> Opening your editor to finalize release notes.", fg="cyan")
-    release_notes = (
-        datetime.datetime.now(datetime.timezone.utc)
-        .astimezone(timezone("US/Pacific"))
-        .strftime("%m-%d-%Y %H:%M %Z\n\n")
-    )
-    release_notes += "\n".join(f"- {change}" for change in ctx.changes)
+    release_notes = "\n".join(f"- {change}" for change in ctx.changes)
     ctx.release_notes = releasetool.filehelpers.open_editor_with_tempfile(
         release_notes, "release-notes.md"
     ).strip()
@@ -208,7 +202,6 @@ def start() -> None:
     determine_last_release(ctx)
     gather_changes(ctx)
     edit_release_notes(ctx)
-    update_changelog(ctx)
     determine_release_version(ctx)
     create_release_branch(ctx)
     update_changelog(ctx)


### PR DESCRIPTION
Re-add edit_release_notes to initialize ctx.release_notes.

[fixes #62]