### PR TITLE
Support batched releases in Ruby

### DIFF
--- a/releasetool/commands/start/ruby.py
+++ b/releasetool/commands/start/ruby.py
@@ -82,14 +82,17 @@ def determine_last_release(ctx: Context) -> None:
 def gather_changes(ctx: Context) -> None:
     click.secho(f"> Gathering changes since {ctx.last_release_version}", fg="cyan")
     ctx.changes = releasetool.git.summary_log(
-        from_=ctx.last_release_committish, to=f"{ctx.upstream_name}/master"
+        from_=ctx.last_release_committish,
+        to=f"{ctx.upstream_name}/master",
+        format="%b%n%n%n%n",
+        split="\n\n\n\n",
     )
     click.secho(f"Cool, {len(ctx.changes)} changes found.")
 
 
 def edit_release_notes(ctx: Context) -> None:
     click.secho("> Opening your editor to finalize release notes.", fg="cyan")
-    release_notes = "\n".join(f"* {change}" for change in ctx.changes)
+    release_notes = "".join(ctx.changes)
     ctx.release_notes = releasetool.filehelpers.open_editor_with_tempfile(
         release_notes, "release-notes.md"
     ).strip()

--- a/releasetool/commands/tag/ruby.py
+++ b/releasetool/commands/tag/ruby.py
@@ -65,7 +65,7 @@ def determine_release_commit(ctx: Context) -> None:
     click.secho("> Please pick one of the following commits to release:\n")
     for n, commit in enumerate(release_commits, 1):
         title = commit["commit"]["message"].split("\n")[0]
-        print(f"\t{n}: {title} ({commit['sha']})")
+        print(f"\t{n}: {title}")
 
     commit_idx = click.prompt(
         "\nWhich commit do you want to tag and release?", type=int
@@ -79,7 +79,7 @@ def determine_release_tag(ctx: Context) -> None:
     click.secho("> Determining the release tag.", fg="cyan")
     click.secho(f"The commit message is: {ctx.release_commit_message}")
 
-    match = re.match("^Release ([a-z-]+) (\d\.\d.\d)", ctx.release_commit_message)
+    match = re.match("^Release ([a-z-]+) (\d+\.\d+.\d+)", ctx.release_commit_message)
 
     if match is not None:
         ctx.package_name = match.group(1)
@@ -98,13 +98,14 @@ def determine_release_tag(ctx: Context) -> None:
     click.secho(f"Package name is {ctx.package_name}")
     click.secho(f"Package version is {ctx.release_version}")
     click.secho(f"Release tag is {ctx.release_tag}")
+    click.secho(f"Release target commit is {ctx.release_pr['merge_commit_sha']}")
 
 
 def determine_package_name_and_version(ctx: Context) -> None:
     click.secho(
         "> Determining the package name and version from your release tag.", fg="cyan"
     )
-    match = re.match("^([a-z-]+)\/v(\d.\d.\d)$", ctx.release_tag)
+    match = re.match("^([a-z-]+)\/v(\d+.\d+.\d+)$", ctx.release_tag)
     ctx.package_name = match.group(1)
     ctx.release_version = match.group(2)
 
@@ -136,7 +137,7 @@ def create_release(ctx: Context) -> None:
     ctx.github_release = ctx.github.create_release(
         repository=ctx.upstream_repo,
         tag_name=ctx.release_tag,
-        target_committish=ctx.release_commit["sha"],
+        target_committish=ctx.release_pr["merge_commit_sha"],
         name=f"Release {ctx.package_name} {ctx.release_version}",
         body=ctx.release_notes,
     )

--- a/releasetool/filehelpers.py
+++ b/releasetool/filehelpers.py
@@ -72,6 +72,14 @@ def insert_before(
         fh.write(output)
 
 
+def detect(filename: str, expr: str) -> bool:
+    with open(filename, "r") as fh:
+        content = fh.read()
+
+        matches = re.search(expr, content, re.MULTILINE)
+        return matches is not None
+
+
 def replace(filename: str, expr: str, replacement: str) -> None:
     with open(filename, "r+") as fh:
         content = fh.read()

--- a/releasetool/git.py
+++ b/releasetool/git.py
@@ -28,12 +28,18 @@ def list_tags() -> Sequence[str]:
 
 
 def summary_log(
-    from_: str, to: str = "origin/master", where: str = ".", format: str = "%s"
+    from_: str,
+    to: str = "origin/master",
+    where: str = ".",
+    format: str = "%s",
+    split: str = "\n",
 ) -> Sequence[str]:
     output = subprocess.check_output(
         ["git", "log", f"--format={format}", f"{from_}..{to}", where]
     ).decode("utf-8")
-    commits = output.strip().split("\n")
+    commits = output.strip()
+    if split:
+        commits = commits.split(split)
     return commits
 
 

--- a/releasetool/git.py
+++ b/releasetool/git.py
@@ -28,13 +28,18 @@ def list_tags() -> Sequence[str]:
 
 
 def summary_log(
-    from_: str, to: str = "origin/master", where: str = "."
+    from_: str, to: str = "origin/master", where: str = ".", format: str = "%s"
 ) -> Sequence[str]:
     output = subprocess.check_output(
-        ["git", "log", "--format=%s", f"{from_}..{to}", where]
+        ["git", "log", f"--format={format}", f"{from_}..{to}", where]
     ).decode("utf-8")
     commits = output.strip().split("\n")
     return commits
+
+
+def get_current_branch() -> str:
+    output = subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"])
+    return output.decode("utf-8").strip()
 
 
 def checkout_create_branch(branch_name: str, base: str = "origin/master") -> None:

--- a/releasetool/github.py
+++ b/releasetool/github.py
@@ -39,6 +39,12 @@ class GitHub:
         response.raise_for_status()
         return response.json()
 
+    def list_pull_request_commits(self, repository: str, number: str) -> Sequence[dict]:
+        url = f"{_GITHUB_ROOT}/repos/{repository}/pulls/{number}/commits"
+        response = self.session.get(url)
+        response.raise_for_status()
+        return response.json()
+
     def create_pull_request(
         self, repository: str, head: str, title: str, body: str = None
     ) -> dict:


### PR DESCRIPTION
This change to the Ruby `start` and `tag` commands adds support for releasing multiple packages in a single PR. 

* See the current google-cloud-ruby [RELEASING.md](https://github.com/googleapis/google-cloud-ruby/blob/master/RELEASING.md) for the existing manual release workflow this change is intended to sustain. 
* See a [proposed update to RELEASING.md](https://github.com/quartzmo/google-cloud-ruby/blob/releasing-update/RELEASING.md) for usage of releasetool in the same workflow.

This PR makes non-breaking changes to the shared files `git.py` and `github.py`.