### PR TITLE
Java: support multiple versions per release

### DIFF
--- a/releasetool/commands/start/java.py
+++ b/releasetool/commands/start/java.py
@@ -149,6 +149,7 @@ def determine_release_type(ctx: Context) -> None:
 
 
 def read_versions(ctx: Context) -> None:
+    """Parses current artifact versions from the versions.txt manifest file"""
     click.secho("> Figuring out the current version(s)", fg="cyan")
 
     versions = []
@@ -164,12 +165,14 @@ def read_versions(ctx: Context) -> None:
 
 
 def bump_versions(ctx: Context) -> None:
+    """Bump all versions according to the release type"""
     for versions in ctx.versions:
         versions.bump(ctx.release_type)
 
 
 def update_versions(ctx: Context) -> None:
-    if click.confirm("Bump versions?", default=True):
+    """Update the versions.txt manifest file"""
+    if click.confirm("Update versions.txt?", default=True):
         with open("versions.txt", "w") as f:
             f.write("# Format:\n")
             f.write("# module:released-version:current-version\n\n")
@@ -178,6 +181,7 @@ def update_versions(ctx: Context) -> None:
 
 
 def replace_versions(ctx: Context) -> None:
+    """Replaces version strings in source and build files"""
     if click.confirm("Update versions in pom.xml files?", default=True):
         updated_files = []
         for root, _, files in os.walk("."):
@@ -190,6 +194,7 @@ def replace_versions(ctx: Context) -> None:
 
 
 def replace_version_in_file(versions: List[ArtifactVersions], target: str):
+    """Replaces all annotated versions in a single file"""
     newlines = []
     version_map = {}
     for av in versions:
@@ -282,6 +287,7 @@ def gather_changes(ctx: Context) -> None:
 
 
 def determine_release_version(ctx: Context) -> None:
+    """Determines the release version for release tagging"""
     click.secho(f"> Now it's time to pick a release version!", fg="cyan")
     release_notes = textwrap.indent(ctx.release_notes, "\t")
     click.secho(f"Here's the release notes you wrote:\n\n{release_notes}\n")
@@ -315,6 +321,7 @@ def create_release_branch(ctx: Context) -> None:
 
 
 def create_release_pr(ctx: Context) -> None:
+    """Create a release pull request with notes"
     if ctx.release_branch is not None and click.confirm("Create PR?", default=True):
         click.secho(f"> Creating release pull request.", fg="cyan")
 

--- a/releasetool/commands/start/java.py
+++ b/releasetool/commands/start/java.py
@@ -301,7 +301,9 @@ def create_release_branch(ctx: Context) -> None:
             if ctx.release_type == "snapshot"
             else f"Release v{ctx.release_version}"
         )
-        releasetool.git.commit(["README.md", "versions.txt"] + ctx.updated_files, message)
+        releasetool.git.commit(
+            ["README.md", "versions.txt"] + ctx.updated_files, message
+        )
 
         click.secho("> Pushing release branch.", fg="cyan")
         releasetool.git.push(ctx.release_branch)

--- a/releasetool/commands/start/java.py
+++ b/releasetool/commands/start/java.py
@@ -32,6 +32,7 @@ VERSION_REGEX = re.compile(r"(\d+)\.(\d+)\.(\d+)(-\w+)?(-\w+)?")
 VERSION_UPDATE_MARKER = re.compile(r"\{x-version-update:([^:]+):([^}]+)\}")
 VERSION_UPDATE_START_MARKER = re.compile(r"\{x-version-update-start:([^:]+):([^}]+)\}")
 VERSION_UPDATE_END_MARKER = re.compile(r"\{x-version-update-end\}")
+RELEASE_TAG_REGEX = re.compile(r"v?(\d+)\.(\d+)\.(\d+)")
 
 
 class Version:
@@ -244,7 +245,7 @@ def determine_package_name(ctx: Context) -> None:
 def determine_last_release(ctx: Context) -> None:
     click.secho("> Figuring out what the last release was.", fg="cyan")
     tags = releasetool.git.list_tags()
-    candidates = [tag for tag in tags if tag.startswith("v")]
+    candidates = [tag for tag in tags if RELEASE_TAG_REGEX.match(tag)]
 
     if candidates:
         ctx.last_release_committish = candidates[0]
@@ -259,7 +260,7 @@ def determine_last_release(ctx: Context) -> None:
             fg="yellow",
         )
         ctx.last_release_committish = click.prompt("Committish")
-        ctx.last_release_version = "0.0.0"
+        ctx.last_release_version = click.prompt("Last version", default="0.0.0")
 
     click.secho(f"The last release was {ctx.last_release_version}.")
 

--- a/releasetool/commands/start/java.py
+++ b/releasetool/commands/start/java.py
@@ -321,7 +321,7 @@ def create_release_branch(ctx: Context) -> None:
 
 
 def create_release_pr(ctx: Context) -> None:
-    """Create a release pull request with notes"
+    """Create a release pull request with notes"""
     if ctx.release_branch is not None and click.confirm("Create PR?", default=True):
         click.secho(f"> Creating release pull request.", fg="cyan")
 

--- a/releasetool/commands/start/java.py
+++ b/releasetool/commands/start/java.py
@@ -130,6 +130,7 @@ class Context(releasetool.commands.common.GitHubContext):
     updated_files: List[str] = []
     versions: List[ArtifactVersions] = None
 
+
 def determine_release_type(ctx: Context) -> None:
     ctx.release_type = click.prompt(
         "What type of release is this? (minor|patch|snapshot)",

--- a/releasetool/commands/start/java.py
+++ b/releasetool/commands/start/java.py
@@ -67,6 +67,9 @@ class Version:
         elif bump_type == "patch":
             self.bump_patch()
             self.set_snapshot(False)
+        elif bump_type == "snapshot":
+            self.bump_patch()
+            self.set_snapshot(True)
         else:
             raise ValueError("invalid bump_type: {}".format(bump_type))
 

--- a/releasetool/commands/start/java.py
+++ b/releasetool/commands/start/java.py
@@ -33,6 +33,11 @@ VERSION_UPDATE_MARKER = re.compile(r"\{x-version-update:([^:]+):([^}]+)\}")
 VERSION_UPDATE_START_MARKER = re.compile(r"\{x-version-update-start:([^:]+):([^}]+)\}")
 VERSION_UPDATE_END_MARKER = re.compile(r"\{x-version-update-end\}")
 RELEASE_TAG_REGEX = re.compile(r"v?(\d+)\.(\d+)\.(\d+)")
+VERSION_REPLACEMENT_FILENAMES = {
+    "README.md": True,
+    "pom.xml": True,
+    "build.gradle": True,
+}
 
 
 class Version:
@@ -178,7 +183,7 @@ def replace_versions(ctx: Context) -> None:
         for root, _, files in os.walk("."):
             for filename in files:
                 filepath = root + os.sep + filename
-                if filename == "README.md" or filename == "pom.xml":
+                if filename in VERSION_REPLACEMENT_FILENAMES:
                     replace_version_in_file(ctx.versions, filepath)
                     updated_files.append(filepath)
         ctx.updated_files = updated_files

--- a/releasetool/commands/start/java.py
+++ b/releasetool/commands/start/java.py
@@ -29,6 +29,59 @@ import releasetool.github
 import releasetool.secrets
 import releasetool.commands.common
 
+VERSION_REGEX = re.compile(r'(\d+)\.(\d+)\.(\d+)(-\w+)?(-\w+)?')
+
+class Version:
+    major: str = None
+    minor: str = None
+    patch: str = None
+    variant: str = None
+    snapshot: bool = False
+
+    def __init__(self, version_str):
+        match = VERSION_REGEX.match(version_str)
+        self.major = int(match.group(1))
+        self.minor = int(match.group(2))
+        self.patch = int(match.group(3))
+        qualifier1 = match.group(4)
+        qualifier2 = match.group(5)
+        if qualifier1 and qualifier2:
+            if qualifier2 == '-SNAPSHOT':
+                self.variant = qualifier1
+                self.snapshot = True
+            else:
+                self.variant = qualifier1 + qualifier2
+        elif qualifier1:
+            if qualifier1 == '-SNAPSHOT':
+                self.snapshot = True
+            else:
+                self.variant = qualifier1
+
+    def bump(self, bump_type):
+        if bump_type == 'minor':
+            self.bump_minor()
+        elif bump_type == 'patch':
+            self.bump_patch()
+        else:
+            raise ValueError('invalid bump_type: {}'.format(bump_type))
+
+    def bump_minor(self):
+        self.minor += 1
+        self.patch = 0
+
+    def bump_patch(self):
+        self.patch += 1
+
+    def set_snapshot(self, snapshot):
+        self.snapshot = snapshot
+
+    def __str__(self):
+        mmp = '{}.{}.{}'.format(self.major, self.minor, self.patch)
+        postfix = self.variant
+        if self.snapshot:
+            postfix += '-SNAPSHOT'
+        return mmp + postfix
+
 
 @attr.s(auto_attribs=True, slots=True)
 class Context(releasetool.commands.common.GitHubContext):
@@ -192,21 +245,24 @@ def create_release_pr(ctx: Context) -> None:
 def start() -> None:
     ctx = Context()
 
-    click.secho(f"o/ Hey, {getpass.getuser()}, let's release some stuff!", fg="magenta")
+    version = Version("1.2.3-alpha-SNAPSHOT")
+    print(version)
 
-    releasetool.commands.common.setup_github_context(ctx)
-    determine_package_name(ctx)
-    determine_last_release(ctx)
-    determine_snapshot_version(ctx)
-    gather_changes(ctx)
-    releasetool.commands.common.edit_release_notes(ctx)
-    determine_release_version(ctx)
-    create_release_branch(ctx)
-    gather_pom_xml_files(ctx)
-    update_pom_xml(ctx)
-    create_release_commit(ctx)
-    push_release_branch(ctx)
-    # TODO: Confirm?
-    create_release_pr(ctx)
+    # click.secho(f"o/ Hey, {getpass.getuser()}, let's release some stuff!", fg="magenta")
 
-    click.secho(f"\o/ All done!", fg="magenta")
+    # releasetool.commands.common.setup_github_context(ctx)
+    # determine_package_name(ctx)
+    # determine_last_release(ctx)
+    # determine_snapshot_version(ctx)
+    # gather_changes(ctx)
+    # releasetool.commands.common.edit_release_notes(ctx)
+    # determine_release_version(ctx)
+    # create_release_branch(ctx)
+    # gather_pom_xml_files(ctx)
+    # update_pom_xml(ctx)
+    # create_release_commit(ctx)
+    # push_release_branch(ctx)
+    # # TODO: Confirm?
+    # create_release_pr(ctx)
+
+    # click.secho(f"\o/ All done!", fg="magenta")

--- a/releasetool/commands/start/java.py
+++ b/releasetool/commands/start/java.py
@@ -116,8 +116,8 @@ class ArtifactVersions:
         self.current.set_snapshot(True)
 
     def next_release(self, bump_type=str) -> None:
-        self.current.bump(bump_type)
-        self.released = copy.deepcopy(self.current)
+        self.released.bump(bump_type)
+        self.current = copy.deepcopy(self.released)
 
     def __str__(self) -> str:
         return "{}:{}:{}".format(self.module, self.released, self.current)


### PR DESCRIPTION
Java publishes packages together and different artifacts are versioned independently. We already have precedent in google-cloud-java to manage all versions in a `versions.txt` file at the root directory and to be able to annotate places to replace throughout the `README.md` and `pom.xml` files.

This PR replaces the current `utilites/bump_versions.py` and `utilities/replace_versions.py` scripts in google-cloud-java so they can be used with other repositories like gax-java.

The workflow is now:
1. What type of release? (MINOR|patch|snapshot)
2. Bump versions.txt? (Y/n)
3. Update versions in pom.xml files? (Y/n)
4. Edit release notes
5. Create release branch? (Y/n)
6. Create PR? (Y/n)

See https://github.com/googleapis/google-cloud-java/issues/3777

This should make releasetool work for all of google-cloud-java, gax-java, google-auth-library-java, google-api-java-client, google-http-java-client, google-oauth-java-client.