### PR TITLE
Cut release branch from master, warn when master != upstream/master.

### DIFF
--- a/releasetool/commands/common.py
+++ b/releasetool/commands/common.py
@@ -91,6 +91,19 @@ def setup_github_context(
 
     click.secho(f"Origin: {ctx.origin_repo}, Upstream: {ctx.upstream_repo}")
 
+    # Compare upstream/master with master
+    click.secho(f"> Comparing {ctx.upstream_name}/master to master.", fg="cyan")
+
+    if releasetool.git.diff(f"{ctx.upstream_name}/master", "master") == "":
+        click.echo(f"master is up to date with {ctx.upstream_name}/master")
+    else:
+        click.secho(
+            f"WARNING: master is not up to date with {ctx.upstream_name}/master",
+            fg="red",
+        )
+        if click.confirm("> Would you like to continue?") is False:
+            exit()
+
 
 def edit_release_notes(ctx: GitHubContext) -> None:
     click.secho(f"> Opening your editor to finalize release notes.", fg="cyan")

--- a/releasetool/commands/common.py
+++ b/releasetool/commands/common.py
@@ -94,7 +94,9 @@ def setup_github_context(
     # Compare upstream/master with master
     click.secho(f"> Comparing {ctx.upstream_name}/master to master.", fg="cyan")
 
-    if releasetool.git.diff(f"{ctx.upstream_name}/master", "master") == "":
+    if releasetool.git.get_latest_commit(
+        f"{ctx.upstream_name}/master"
+    ) == releasetool.git.get_latest_commit("master"):
         click.echo(f"master is up to date with {ctx.upstream_name}/master")
     else:
         click.secho(

--- a/releasetool/commands/start/python.py
+++ b/releasetool/commands/start/python.py
@@ -84,7 +84,7 @@ def determine_last_release(ctx: Context) -> None:
 def gather_changes(ctx: Context) -> None:
     click.secho(f"> Gathering changes since {ctx.last_release_version}", fg="cyan")
     ctx.changes = releasetool.git.summary_log(
-        from_=ctx.last_release_committish, to=f"{ctx.upstream_name}/master"
+        from_=ctx.last_release_committish, to=f"master"
     )
     ctx.changes = [
         ctx.github.link_pull_request(c, ctx.upstream_repo) for c in ctx.changes

--- a/releasetool/git.py
+++ b/releasetool/git.py
@@ -27,9 +27,12 @@ def list_tags() -> Sequence[str]:
     return tags
 
 
-def summary_log(
-    from_: str, to: str = "origin/master", where: str = "."
-) -> Sequence[str]:
+def diff(from_: str, to: str = "master") -> bool:
+    output = subprocess.check_output(["git", "diff", from_, to]).decode("utf-8")
+    return output
+
+
+def summary_log(from_: str, to: str = "master", where: str = ".") -> Sequence[str]:
     output = subprocess.check_output(
         ["git", "log", "--format=%s", f"{from_}..{to}", where]
     ).decode("utf-8")
@@ -37,7 +40,7 @@ def summary_log(
     return commits
 
 
-def checkout_create_branch(branch_name: str, base: str = "origin/master") -> None:
+def checkout_create_branch(branch_name: str, base: str = "master") -> None:
     subprocess.check_output(["git", "checkout", "-b", branch_name, base])
 
 

--- a/releasetool/git.py
+++ b/releasetool/git.py
@@ -27,9 +27,11 @@ def list_tags() -> Sequence[str]:
     return tags
 
 
-def diff(from_: str, to: str = "master") -> bool:
-    output = subprocess.check_output(["git", "diff", from_, to]).decode("utf-8")
-    return output
+def get_latest_commit(branch: str) -> str:
+    commit = subprocess.check_output(
+        ["git", "log", "-1", branch, "--pretty=%H"]
+    ).decode("utf-8")
+    return commit
 
 
 def summary_log(from_: str, to: str = "master", where: str = ".") -> Sequence[str]:


### PR DESCRIPTION
Closes #66 

* Release branch is cut from `master` instead of `origin/master`
* Releasetool checks that `master` is up to date with the upstream master branch.

```
/ Hey, busunkim, let's release some stuff!
> Determining GitHub context.
Origin: busunkim96/google-cloud-python, Upstream: GoogleCloudPlatform/google-cloud-python
> Comparing upstream/master to master.
master is up to date with upstream/master
...
```

```
o/ Hey, busunkim, let's release some stuff!
> Determining GitHub context.
Origin: busunkim96/google-cloud-python, Upstream: GoogleCloudPlatform/google-cloud-python
> Comparing upstream/master to master.
WARNING: master is not up to date with upstream/master
> Would you like to continue? [y/N]: y
...
```
