### PR TITLE
Add command to reset GitHub API key

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -21,15 +21,8 @@ cd github/releasetool
 # Disable buffering, so that the logs stream through.
 export PYTHONUNBUFFERED=1
 
-# Remove old nox.
-python3 -m pip uninstall --yes --quiet nox-automation
-
-# Install nox.
-python3 -m pip install --upgrade --quiet nox
-python3 -m nox --version
-
 # Run tests
-python3 -m nox -s lint test
+nox -s lint test
 
 # remove all files, preventing kokoro from trying to sync them.
 rm -rf *

--- a/README.md
+++ b/README.md
@@ -35,3 +35,7 @@ releasetool start
 
 Once the PR has been approved and merged, you can run `releasetool tag` from
 anywhere in the repository to tag the commit and start CI.
+
+If you need to change the GitHub API token associated with releasetool, run `releasetool reset`. This will
+delete the existing token. The next time you run `releasetool start` you will be
+prompted to enter a new token. 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,5 @@ releasetool start
 Once the PR has been approved and merged, you can run `releasetool tag` from
 anywhere in the repository to tag the commit and start CI.
 
-If you need to change the GitHub API token associated with releasetool, run `releasetool reset`. This will
-delete the existing token. The next time you run `releasetool start` you will be
-prompted to enter a new token. 
+If you need to change the GitHub API token associated with releasetool, run `releasetool reset-config`. This will delete the existing token. The next time you run `releasetool start` you will be
+prompted to enter a new token.

--- a/releasetool/main.py
+++ b/releasetool/main.py
@@ -17,6 +17,7 @@ import os
 
 import click
 
+import releasetool.secrets
 import releasetool.update_check
 import releasetool.commands.start.python
 import releasetool.commands.start.python_tool
@@ -123,3 +124,8 @@ def tag(language):
         return releasetool.commands.tag.java.tag()
     if language == "ruby":
         return releasetool.commands.tag.ruby.tag()
+
+
+@main.command()
+def reset():
+    releasetool.secrets.delete_password()

--- a/releasetool/main.py
+++ b/releasetool/main.py
@@ -126,6 +126,6 @@ def tag(language):
         return releasetool.commands.tag.ruby.tag()
 
 
-@main.command()
-def reset():
+@main.command(name="reset-config")
+def reset_config():
     releasetool.secrets.delete_password()

--- a/releasetool/secrets.py
+++ b/releasetool/secrets.py
@@ -27,6 +27,10 @@ def set_password(name, password):
     keyring.set_password(_SERVICE, "github", password)
 
 
+def delete_password():
+    keyring.delete_password(_SERVICE, "github")
+
+
 def ensure_password(name, prompt):
     password = get_password(name)
 


### PR DESCRIPTION
`releasetool reset` will delete the GitHub API key from keyring.

Closes #78.