### PR TITLE
Allow python-tool tag to be executed with external context.

### DIFF
--- a/releasetool/commands/start/go.py
+++ b/releasetool/commands/start/go.py
@@ -176,7 +176,7 @@ def update_changelog(ctx: Context) -> None:
         f"## v{ctx.release_version}" f"\n\n" f"{ctx.release_notes}" f"\n\n"
     )
     releasetool.filehelpers.insert_before(
-        _CHANGELOG_FILENAME, changelog_entry, "^## (.+)$|\Z"
+        _CHANGELOG_FILENAME, changelog_entry, r"^## (.+)$|\Z"
     )
 
 
@@ -220,4 +220,4 @@ def start() -> None:
     create_release_commit(ctx)
     create_release_cl(ctx)
 
-    click.secho(f"\o/ All done!", fg="magenta")
+    click.secho(f"\\o/ All done!", fg="magenta")

--- a/releasetool/commands/start/java.py
+++ b/releasetool/commands/start/java.py
@@ -372,4 +372,4 @@ def start() -> None:
     create_release_branch(ctx)
     create_release_pr(ctx)
 
-    click.secho(f"\o/ All done!", fg="magenta")
+    click.secho(f"\\o/ All done!", fg="magenta")

--- a/releasetool/commands/start/nodejs.py
+++ b/releasetool/commands/start/nodejs.py
@@ -142,7 +142,7 @@ def update_changelog(ctx: Context) -> None:
         f"## v{ctx.release_version}" f"\n\n" f"{ctx.release_notes}" f"\n\n"
     )
     releasetool.filehelpers.insert_before(
-        changelog_filename, changelog_entry, "^## (.+)$|\Z"
+        changelog_filename, changelog_entry, r"^## (.+)$|\Z"
     )
 
 
@@ -216,4 +216,4 @@ def start() -> None:
     # TODO: Confirm?
     create_release_pr(ctx)
 
-    click.secho(f"\o/ All done!", fg="magenta")
+    click.secho(f"\\o/ All done!", fg="magenta")

--- a/releasetool/commands/start/python.py
+++ b/releasetool/commands/start/python.py
@@ -143,7 +143,7 @@ def update_changelog(ctx: Context) -> None:
 
     changelog_entry = f"## {ctx.release_version}" f"\n\n" f"{ctx.release_notes}" f"\n\n"
     releasetool.filehelpers.insert_before(
-        changelog_filename, changelog_entry, "^## (.+)$|\Z"
+        changelog_filename, changelog_entry, r"^## (.+)$|\Z"
     )
 
 
@@ -203,4 +203,4 @@ def start() -> None:
     # TODO: Confirm?
     create_release_pr(ctx)
 
-    click.secho(f"\o/ All done!", fg="magenta")
+    click.secho(f"\\o/ All done!", fg="magenta")

--- a/releasetool/commands/start/ruby.py
+++ b/releasetool/commands/start/ruby.py
@@ -149,7 +149,7 @@ def update_changelog(ctx: Context) -> None:
         f"### {ctx.release_version} / {today}" f"\n\n" f"{ctx.release_notes}" f"\n\n"
     )
     releasetool.filehelpers.insert_before(
-        changelog_filename, changelog_entry, "^### (.+)$|\Z"
+        changelog_filename, changelog_entry, r"^### (.+)$|\Z"
     )
 
 
@@ -211,4 +211,4 @@ def start() -> None:
     # TODO: Confirm?
     create_release_pr(ctx)
 
-    click.secho(f"\o/ All done!", fg="magenta")
+    click.secho(f"\\o/ All done!", fg="magenta")

--- a/releasetool/commands/tag/java.py
+++ b/releasetool/commands/tag/java.py
@@ -56,7 +56,7 @@ def determine_release_pr(ctx: Context) -> None:
 def determine_release_tag(ctx: Context) -> None:
     click.secho("> Determining what the release tag should be.", fg="cyan")
     head_ref = ctx.release_pr["head"]["ref"]
-    match = re.match("release-.+-(v\d+\.\d+\.\d+)", head_ref)
+    match = re.match(r"release-.+-(v\d+\.\d+\.\d+)", head_ref)
 
     if match is not None:
         ctx.release_tag = match.group(1)
@@ -75,7 +75,7 @@ def determine_release_tag(ctx: Context) -> None:
 
 def determine_package_name_and_version(ctx: Context) -> None:
     click.secho("> Determining the release version.", fg="cyan")
-    match = re.match("v(\d+\.\d+\.\d+)", ctx.release_tag)
+    match = re.match(r"v(\d+\.\d+\.\d+)", ctx.release_tag)
     ctx.release_version = match.group(1)
     click.secho(f"Package version: {ctx.release_version}.")
 
@@ -129,4 +129,4 @@ def tag() -> None:
 
     create_release(ctx)
 
-    click.secho(f"\o/ All done!", fg="magenta")
+    click.secho(f"\\o/ All done!", fg="magenta")

--- a/releasetool/commands/tag/nodejs.py
+++ b/releasetool/commands/tag/nodejs.py
@@ -75,7 +75,7 @@ def determine_release_tag(ctx: Context) -> None:
 
 def determine_package_version(ctx: Context) -> None:
     click.secho("> Determining the package version.", fg="cyan")
-    match = re.match("(?P<version>v?\d+?\.\d+?\.\d+?)", ctx.release_tag)
+    match = re.match(r"(?P<version>v?\d+?\.\d+?\.\d+?)", ctx.release_tag)
     ctx.release_version = match.group("version")
     click.secho(f"package version: {ctx.release_version}.")
 
@@ -147,4 +147,4 @@ def tag() -> None:
     create_release(ctx)
     wait_on_circle(ctx)
 
-    click.secho(f"\o/ All done!", fg="magenta")
+    click.secho(f"\\o/ All done!", fg="magenta")

--- a/releasetool/commands/tag/python.py
+++ b/releasetool/commands/tag/python.py
@@ -74,7 +74,7 @@ def determine_release_tag(ctx: Context) -> None:
 
 def determine_package_name_and_version(ctx: Context) -> None:
     click.secho("> Determining the package name and version.", fg="cyan")
-    match = re.match("(?P<name>.+?)-(?P<version>\d+?\.\d+?\.\d+?)", ctx.release_tag)
+    match = re.match(r"(?P<name>.+?)-(?P<version>\d+?\.\d+?\.\d+?)", ctx.release_tag)
     ctx.package_name = match.group("name")
     ctx.release_version = match.group("version")
     click.secho(
@@ -151,4 +151,4 @@ def tag() -> None:
     create_release(ctx)
     wait_on_circle(ctx)
 
-    click.secho(f"\o/ All done!", fg="magenta")
+    click.secho(f"\\o/ All done!", fg="magenta")

--- a/releasetool/commands/tag/python_tool.py
+++ b/releasetool/commands/tag/python_tool.py
@@ -100,6 +100,6 @@ def tag(ctx: Context = None) -> Context:
 
     publish_to_pypi(ctx)
 
-    click.secho(f"\o/ All done!", fg="magenta")
+    click.secho(f"\\o/ All done!", fg="magenta")
 
     return ctx

--- a/releasetool/commands/tag/ruby.py
+++ b/releasetool/commands/tag/ruby.py
@@ -57,7 +57,7 @@ def determine_release_tag(ctx: Context) -> None:
     click.secho("> Determining the release tag.", fg="cyan")
     head_ref = ctx.release_pr["head"]["ref"]
     click.secho(f"PR head ref is {head_ref}")
-    match = re.match("^release-([a-z-]+)-v(\d\.\d.\d)$", head_ref)
+    match = re.match(r"^release-([a-z-]+)-v(\d\.\d.\d)$", head_ref)
 
     if match is not None:
         ctx.package_name = match.group(1)
@@ -83,7 +83,7 @@ def determine_package_name_and_version(ctx: Context) -> None:
     click.secho(
         "> Determining the package name and version from your release tag.", fg="cyan"
     )
-    match = re.match("^([a-z-]+)\/v(\d.\d.\d)$", ctx.release_tag)
+    match = re.match(r"^([a-z-]+)\/v(\d.\d.\d)$", ctx.release_tag)
     ctx.package_name = match.group(1)
     ctx.release_version = match.group(2)
 
@@ -158,4 +158,4 @@ def tag() -> None:
     create_release(ctx)
     wait_on_circle(ctx)
 
-    click.secho(f"\o/ All done!", fg="magenta")
+    click.secho(f"\\o/ All done!", fg="magenta")

--- a/releasetool/github.py
+++ b/releasetool/github.py
@@ -57,7 +57,7 @@ class GitHub:
         return response.json()
 
     def link_pull_request(self, text: str, repository: str) -> str:
-        match = "#(?P<pull_request>\d+)"
+        match = r"#(?P<pull_request>\d+)"
         url = f"{_GITHUB_UI_ROOT}/{repository}/pull/\\g<pull_request>"
         replacement = f"[#\\g<pull_request>]({url})"
         return re.sub(match, replacement, text)


### PR DESCRIPTION
This will allow autorelease to tag Python releases.