### PR TITLE
Enable Autorelease for Python

### DIFF
--- a/releasetool/commands/start/python.py
+++ b/releasetool/commands/start/python.py
@@ -167,7 +167,7 @@ def push_release_branch(ctx: Context) -> None:
     releasetool.git.push(ctx.release_branch)
 
 
-def create_release_pr(ctx: Context, autorelease: bool = False) -> None:
+def create_release_pr(ctx: Context, autorelease: bool = True) -> None:
     click.secho(f"> Creating release pull request.", fg="cyan")
 
     if ctx.upstream_repo == ctx.origin_repo:

--- a/releasetool/commands/start/python_tool.py
+++ b/releasetool/commands/start/python_tool.py
@@ -57,6 +57,6 @@ def start() -> None:
     releasetool.commands.start.python.create_release_commit(ctx)
     releasetool.commands.start.python.push_release_branch(ctx)
     # TODO: Confirm?
-    releasetool.commands.start.python.create_release_pr(ctx, autorelease=True)
+    releasetool.commands.start.python.create_release_pr(ctx)
 
     click.secho(f"\\o/ All done!", fg="magenta")

--- a/releasetool/commands/tag/python.py
+++ b/releasetool/commands/tag/python.py
@@ -108,6 +108,10 @@ def create_release(ctx: TagContext) -> None:
         ctx.upstream_repo, ctx.release_pr["number"], release_location_string
     )
 
+    ctx.github.update_pull_labels(
+        ctx.release_pr, add=["autorelease: tagged"], remove=["autorelease: pending"]
+    )
+
 
 def tag(ctx: TagContext = None) -> TagContext:
     if not ctx:


### PR DESCRIPTION
Finishing Autorelease setup for Python. 

Do not merge until Autorelease has been enabled for google-cloud-python jobs. 

@theacodes google-cloud-python has Kokoro release jobs now. Is Autorelease ready for Python, or are there modifications that need to be made? 