### PR TITLE
get commit hash from git log

### DIFF
--- a/releasetool/commands/tag/ruby.py
+++ b/releasetool/commands/tag/ruby.py
@@ -124,12 +124,12 @@ def create_release(ctx: TagContext) -> None:
 
 
 def determine_commit_hash(ctx: TagContext) -> str:
-    out, _ = Popen('git log --pretty=oneline', stdout=PIPE, shell=True).communicate()
+    out, _ = Popen("git log --pretty=oneline", stdout=PIPE, shell=True).communicate()
     out = out.decode("utf-8").split("\n")
     for line in out:
-        if '(tag: ' in line:
+        if "(tag: " in line:
             next
-        if f'Release {ctx.package_name}' in line and f'(#{ctx.release_pr})' in line:
+        if f"Release {ctx.package_name}" in line and f"(#{ctx.release_pr})" in line:
             return line.split(" ")[0]
     return ctx.release_pr["merge_commit_sha"]
 

--- a/releasetool/commands/tag/ruby.py
+++ b/releasetool/commands/tag/ruby.py
@@ -39,6 +39,7 @@ def determine_release_pr(ctx: TagContext) -> None:
         print(f"\t{n}: {pull['title']} ({pull['number']})")
 
     pull_idx = click.prompt("\nWhich one do you want to tag and release?", type=int)
+
     ctx.release_pr = pulls[pull_idx - 1]
 
 
@@ -100,9 +101,6 @@ def get_release_notes(ctx: TagContext) -> None:
 def create_release(ctx: TagContext) -> None:
     click.secho("> Creating the release.")
     sha = determine_commit_hash(ctx)
-    if len(sha) == 0:
-        sha = ctx.release_pr["merge_commit_sha"]
-
     ctx.github_release = ctx.github.create_release(
         repository=ctx.upstream_repo,
         tag_name=ctx.release_tag,
@@ -132,7 +130,7 @@ def determine_commit_hash(ctx: TagContext) -> str:
             next
         if f'Release {ctx.package_name}' in line and f'(#{ctx.release_pr})' in line:
             return line.split(" ")[0]
-    return ""
+    return ctx.release_pr["merge_commit_sha"]
 
 
 def tag(ctx: TagContext = None) -> TagContext:

--- a/releasetool/commands/tag/ruby.py
+++ b/releasetool/commands/tag/ruby.py
@@ -26,6 +26,7 @@ from releasetool.commands.common import TagContext
 
 from subprocess import Popen, PIPE
 
+
 def determine_release_pr(ctx: TagContext) -> None:
     click.secho(
         "> Let's figure out which pull request corresponds to your release.", fg="cyan"
@@ -104,7 +105,7 @@ def create_release(ctx: TagContext) -> None:
     ctx.github_release = ctx.github.create_release(
         repository=ctx.upstream_repo,
         tag_name=ctx.release_tag,
-        target_committish=ctx.release_pr["merge_commit_sha"],
+        target_committish=sha,
         name=f"Release {ctx.package_name} {ctx.release_version}",
         body=ctx.release_notes,
     )

--- a/releasetool/commands/tag/ruby.py
+++ b/releasetool/commands/tag/ruby.py
@@ -127,15 +127,12 @@ def create_release(ctx: TagContext) -> None:
 def determine_commit_hash(ctx: TagContext) -> str:
     out, _ = Popen('git log --pretty=oneline', stdout=PIPE, shell=True).communicate()
     out = out.decode("utf-8").split("\n")
-    commits = []
     for line in out:
         if '(tag: ' in line:
             next
         if f'Release {ctx.package_name}' in line and f'(#{ctx.release_pr})' in line:
-            commits.append(line)
-    if len(commits) == 0:
-        return ""
-    return commits[0].split(" ")[0]
+            return line.split(" ")[0]
+    return ""
 
 
 def tag(ctx: TagContext = None) -> TagContext:


### PR DESCRIPTION
Currently releasetool seems to be tagging releases to the latest commit on master, rather than necessarily the commit that was the PR merge. 

This is an attempt at addressing that. I'm definitely open to a better way of doing this.