### PR TITLE
Allow underscores in package name

### DIFF
--- a/releasetool/commands/tag/ruby.py
+++ b/releasetool/commands/tag/ruby.py
@@ -71,7 +71,7 @@ def determine_package_name_and_version(ctx: TagContext) -> None:
     click.secho(
         "> Determining the package name and version from your release tag.", fg="cyan"
     )
-    match = re.match(r"^([a-z-]+)\/v(\d+.\d+.\d+)$", ctx.release_tag)
+    match = re.match(r"^([a-z-_]+)\/v(\d+.\d+.\d+)$", ctx.release_tag)
     ctx.package_name = match.group(1)
     ctx.release_version = match.group(2)
 


### PR DESCRIPTION
Some ruby packages have underscores. e.g. `google-cloud-error_reporting`