### PR TITLE
Java: support updating dependencies.properties

### DIFF
--- a/releasetool/commands/start/java.py
+++ b/releasetool/commands/start/java.py
@@ -37,6 +37,7 @@ VERSION_REPLACEMENT_FILENAMES = {
     "README.md": True,
     "pom.xml": True,
     "build.gradle": True,
+    "dependencies.properties": True,
 }
 
 
@@ -182,7 +183,7 @@ def update_versions(ctx: Context) -> None:
 
 def replace_versions(ctx: Context) -> None:
     """Replaces version strings in source and build files"""
-    if click.confirm("Update versions in pom.xml files?", default=True):
+    if click.confirm("Update versions in source and build files?", default=True):
         updated_files = []
         for root, _, files in os.walk("."):
             for filename in files:


### PR DESCRIPTION
Support updating the version numbers in dependencies.properties. This is used by gax-java. (See https://github.com/googleapis/gax-java/pull/705)