### PR TITLE
Detect language python when a directory src/google exists.

### DIFF
--- a/releasetool/__main__.py
+++ b/releasetool/__main__.py
@@ -67,7 +67,7 @@ def _detect_language():
     if os.path.exists("package.json"):
         return "nodejs"
     elif os.path.exists("setup.py"):
-        if os.path.exists("google"):
+        if os.path.exists("google") or os.path.exists("src/google"):
             return "python"
         else:
             return "python-tool"


### PR DESCRIPTION
`releasetool start` will detect the correct language for standalone Python repositories. 