### PR TITLE
ruby: Add checkout_master() to finish of start

### DIFF
--- a/releasetool/commands/start/ruby.py
+++ b/releasetool/commands/start/ruby.py
@@ -215,6 +215,11 @@ def create_release_pr(ctx: Context, autorelease: bool = True) -> None:
     click.secho(f"Pull request is at {ctx.pull_request['html_url']}.")
 
 
+def checkout_master() -> None:
+    click.secho("> Checkout master branch.", fg="cyan")
+    releasetool.git.checkout_branch("master")
+
+
 def start() -> None:
     ctx = Context()
 
@@ -234,5 +239,6 @@ def start() -> None:
     push_release_branch(ctx)
     # TODO: Confirm?
     create_release_pr(ctx)
+    checkout_master()
 
     click.secho(f"\\o/ All done!", fg="magenta")

--- a/releasetool/git.py
+++ b/releasetool/git.py
@@ -46,6 +46,10 @@ def checkout_create_branch(branch_name: str, base: str = "master") -> None:
     subprocess.check_output(["git", "checkout", "-b", branch_name, base])
 
 
+def checkout_branch(branch_name: str) -> None:
+    subprocess.check_output(["git", "checkout", branch_name])
+
+
 def commit(files: Sequence[str], message: str) -> None:
     """Create a release commit."""
     subprocess.check_output(["git", "add"] + list(files))


### PR DESCRIPTION
When releasing more than one package, it's nice to be automatically returned to `master` branch to begin the next release. When things work correctly, there is nothing left to do in the release branch in Ruby after `start` completes.