### PR TITLE
Update releasetool.commands.common.setup_github_context

### DIFF
--- a/releasetool/commands/common.py
+++ b/releasetool/commands/common.py
@@ -79,7 +79,8 @@ def _determine_upstream(ctx: GitHubContext, owners: Tuple[str, ...]) -> None:
                 f"\n\n{options}\n\n"
                 f"Please enter the *name* of one you want to use",
                 fg="yellow",
-            )
+            ),
+            default="origin",
         )
         try:
             upstream = choice, repos[choice]


### PR DESCRIPTION
Improve usability by adding a default value of "origin" to the upstream prompt, since repeatedly typing "origin" when releasing many packages quickly becomes tiresome.