### PR TITLE
fix: release extraction regex was not handling patch releases properly

### DIFF
--- a/releasetool/commands/tag/nodejs.py
+++ b/releasetool/commands/tag/nodejs.py
@@ -89,7 +89,7 @@ def _get_latest_release_notes(ctx: TagContext, changelog: str):
     # used in automated CHANGELOG generation:
     version = re.sub(r"^v", "", ctx.release_version)
     match = re.search(
-        rf"## v?\[?{version}[^\n]*\n(?P<notes>.+?)(\n##\s|\Z)",
+        rf"## v?\[?{version}[^\n]*\n(?P<notes>.+?)(\n##\s|\n### \[?[0-9]+\.|\Z)",
         changelog,
         re.DOTALL | re.MULTILINE,
     )

--- a/tests/commands/tag/test_nodejs.py
+++ b/tests/commands/tag/test_nodejs.py
@@ -84,6 +84,41 @@ All notable changes to this project will be documented in this file. See [standa
 ## [1.3.0](https://github.com/bcoe/examples-conventional-commits/compare/v1.2.1...v1.3.0) (2018-11-03)
 """
 
+fixture_new_style_patch = """
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+## [5.0.0](https://www.github.com/bcoe/c8/compare/v4.1.5...v5.0.0) (2019-05-20)
+
+
+### ⚠ BREAKING CHANGES
+
+* temp directory now defaults to setting for report directory
+
+### Features
+
+* default temp directory to report directory ([#102](https://www.github.com/bcoe/c8/issues/102)) ([8602f4a](https://www.github.com/bcoe/c8/commit/8602f4a))
+* load .nycrc/.nycrc.json to simplify migration ([#100](https://www.github.com/bcoe/c8/issues/100)) ([bd7484f](https://www.github.com/bcoe/c8/commit/bd7484f))
+
+### [4.1.5](https://github.com/bcoe/c8/compare/v4.1.4...v4.1.5) (2019-05-11)
+
+
+### Bug Fixes
+
+* exit with code 1 when report output fails ([#92](https://github.com/bcoe/c8/issues/92)) ([a27b694](https://github.com/bcoe/c8/commit/a27b694))
+* remove the unmaintained mkdirp dependency ([#91](https://github.com/bcoe/c8/issues/91)) ([a465b65](https://github.com/bcoe/c8/commit/a465b65))
+
+
+
+## [4.1.4](https://github.com/bcoe/c8/compare/v4.1.3...v4.1.4) (2019-05-03)
+
+
+### Bug Fixes
+
+* we were not exiting with 1 if mkdir failed ([#89](https://github.com/bcoe/c8/issues/89)) ([fb02ed6](https://github.com/bcoe/c8/commit/fb02ed6))
+"""
+
 
 def test_old_style_release_notes():
     """
@@ -128,4 +163,21 @@ def test_new_style_release_notes_breaking():
 * disclaimer breaks everything"""
     ctx = TagContext(release_version="v2.0.0")
     _get_latest_release_notes(ctx, fixture_new_style_changelog)
+    assert ctx.release_notes == expected
+
+
+def test_extracts_appropriate_release_notes_when_prior_release_is_patch():
+    """
+    see: https://github.com/googleapis/release-please/issues/140
+    """
+    ctx = TagContext(release_version="v5.0.0")
+    _get_latest_release_notes(ctx, fixture_new_style_patch)
+    expected = """### ⚠ BREAKING CHANGES
+
+* temp directory now defaults to setting for report directory
+
+### Features
+
+* default temp directory to report directory ([#102](https://www.github.com/bcoe/c8/issues/102)) ([8602f4a](https://www.github.com/bcoe/c8/commit/8602f4a))
+* load .nycrc/.nycrc.json to simplify migration ([#100](https://www.github.com/bcoe/c8/issues/100)) ([bd7484f](https://www.github.com/bcoe/c8/commit/bd7484f))"""
     assert ctx.release_notes == expected


### PR DESCRIPTION
The regex for extracting a GitHub release was too greedy if the prior release was a patch, rather than breaking change or feature.

see: https://github.com/googleapis/release-please/issues/140