### PR TITLE
Java: autorelease by default

### DIFF
--- a/releasetool/commands/start/java.py
+++ b/releasetool/commands/start/java.py
@@ -366,7 +366,7 @@ def create_release_pr(ctx: Context) -> None:
             ctx.upstream_repo, head=head, title=title, body=body, base=ctx.source_branch
         )
 
-        if click.confirm("Autorelease?", default=False):
+        if ctx.release_type != "snapshot" and click.confirm("Autorelease?", default=True):
             ctx.github.add_issue_labels(
                 ctx.upstream_repo, ctx.pull_request["number"], ["autorelease: pending"]
             )

--- a/releasetool/commands/start/java.py
+++ b/releasetool/commands/start/java.py
@@ -366,7 +366,9 @@ def create_release_pr(ctx: Context) -> None:
             ctx.upstream_repo, head=head, title=title, body=body, base=ctx.source_branch
         )
 
-        if ctx.release_type != "snapshot" and click.confirm("Autorelease?", default=True):
+        if ctx.release_type != "snapshot" and click.confirm(
+            "Autorelease?", default=True
+        ):
             ctx.github.add_issue_labels(
                 ctx.upstream_repo, ctx.pull_request["number"], ["autorelease: pending"]
             )


### PR DESCRIPTION
Don't prompt for autorelease on snapshots
Default the prompt to true for autorelease