### PR TITLE
Fix last release detection for non-cloud packages in Ruby

### DIFF
--- a/releasetool/commands/start/ruby.py
+++ b/releasetool/commands/start/ruby.py
@@ -65,7 +65,7 @@ def gather_tags(ctx: Context) -> None:
 
 def determine_last_release(ctx: Context) -> None:
     candidates = [tag for tag in ctx.tags if tag.startswith(ctx.package_name + "/")]
-    if candidates and "google-cloud" in candidates[0]:
+    if candidates and ctx.package_name in candidates[0]:
         ctx.last_release_committish = candidates[0]
         ctx.last_release_version = candidates[0].rsplit("/").pop().lstrip("v")
     elif ("google-cloud" not in ctx.package_name) and ctx.tags:


### PR DESCRIPTION
The stackdriver package [got the wrong version bump](https://github.com/googleapis/google-cloud-ruby/pull/3483), this PR fixes the problem, hopefully without regression (I tested manually against several google-cloud-* packages and it works fine.)