### PR TITLE
fix: id correct Python release when package names overlap.

### DIFF
--- a/releasetool/commands/start/python.py
+++ b/releasetool/commands/start/python.py
@@ -15,7 +15,7 @@
 import getpass
 import os
 import textwrap
-from typing import List, Optional
+from typing import Optional, Sequence
 
 import attr
 import click
@@ -52,7 +52,7 @@ def determine_package_name(ctx: Context) -> None:
     click.secho(f"Looks like we're releasing {ctx.package_name}.")
 
 
-def find_last_release_tag(tags: List[str], package_name: str) -> Optional[str]:
+def find_last_release_tag(tags: Sequence[str], package_name: str) -> Optional[str]:
     package_names = [package_name, package_name.replace("_", "-")]
     candidates = [tag for tag in tags if tag.rsplit("-")[0] in package_names]
 

--- a/tests/commands/start/test_python.py
+++ b/tests/commands/start/test_python.py
@@ -43,3 +43,59 @@ def test_update_setup_py_sets_version(
         mut.update_setup_py(context)
         mock_file = mock_open()
         mock_file.write.assert_called_once_with(expected)
+
+
+@pytest.mark.parametrize(
+    "tags,package_name,expected",
+    [
+        (
+            ["bonustag", "bigquery-1.3.0", "bigquery-1.2.0", "bigquery-1.0.0"],
+            "bigquery",
+            "bigquery-1.3.0",
+        ),
+        (
+            [
+                "bonustag",
+                "bigquery-1.3.0",
+                "bigquery-1.2.0",
+                "bigquery_storage-0.2.0",
+                "bigquery-1.0.0",
+                "bigquery_datatransfer-0.3.0",
+                "bigquery_datatransfer-0.2.0",
+                "bigquery_storage-0.1.1",
+                "bigquery_datatransfer-0.1.1",
+                "bigquery_storage-0.1.0",
+            ],
+            "bigquery_storage",
+            "bigquery_storage-0.2.0",
+        ),
+        (
+            [
+                "bonustag",
+                "bigquery_datatransfer-0.3.0",
+                "bigquery_storage-0.2.0",
+                "bigquery-1.3.0",
+                "bigquery-1.2.0",
+                "bigquery-1.0.0",
+                "bigquery_datatransfer-0.2.0",
+                "bigquery_datatransfer-0.1.1",
+                "bigquery_storage-0.1.1",
+                "bigquery_storage-0.1.0",
+            ],
+            "bigquery",
+            "bigquery-1.3.0",
+        ),
+        (
+            [
+                "mypackage-1.0.0",
+                "bonustag",
+                "mypackage-0.9.0",
+            ],
+            "myotherpackage",
+            None,
+        )
+    ],
+)
+def find_last_release_tag(mut, tags, package_name, expected):
+    candidate = mut.find_last_release_tag(tags, package_name)
+    assert candidate == expected

--- a/tests/commands/start/test_python.py
+++ b/tests/commands/start/test_python.py
@@ -85,15 +85,7 @@ def test_update_setup_py_sets_version(
             "bigquery",
             "bigquery-1.3.0",
         ),
-        (
-            [
-                "mypackage-1.0.0",
-                "bonustag",
-                "mypackage-0.9.0",
-            ],
-            "myotherpackage",
-            None,
-        )
+        (["mypackage-1.0.0", "bonustag", "mypackage-0.9.0"], "myotherpackage", None),
     ],
 )
 def find_last_release_tag(mut, tags, package_name, expected):


### PR DESCRIPTION
Closes #212