### PR TITLE
Add releasetool tag for PHP.

### DIFF
--- a/releasetool/__main__.py
+++ b/releasetool/__main__.py
@@ -30,6 +30,7 @@ import releasetool.commands.tag.python
 import releasetool.commands.tag.python_tool
 import releasetool.commands.tag.nodejs
 import releasetool.commands.tag.java
+import releasetool.commands.tag.php
 import releasetool.commands.tag.ruby
 
 
@@ -78,7 +79,7 @@ def _detect_language():
     return None
 
 
-_language_choices = ["python", "python-tool", "nodejs", "java", "ruby", "go"]
+_language_choices = ["python", "python-tool", "nodejs", "java", "ruby", "go", "php"]
 
 
 def _language_option():
@@ -123,6 +124,8 @@ def tag(language):
         return releasetool.commands.tag.nodejs.tag()
     if language == "java":
         return releasetool.commands.tag.java.tag()
+    if language == "php":
+        return releasetool.commands.tag.php.tag()
     if language == "ruby":
         return releasetool.commands.tag.ruby.tag()
 

--- a/releasetool/commands/tag/php.py
+++ b/releasetool/commands/tag/php.py
@@ -1,0 +1,38 @@
+import getpass
+
+import click
+
+import releasetool.commands.tag.nodejs
+from releasetool.commands.common import TagContext
+
+
+def tag(ctx: TagContext = None) -> TagContext:
+    # PHP just needs a release to be tagged on GitHub.
+    # Tagging logic is the same as NodeJs.
+    if not ctx:
+        ctx = TagContext()
+
+    if ctx.interactive:
+        click.secho(f"o/ Hey, {getpass.getuser()}, let's tag a release!", fg="magenta")
+
+    if ctx.github is None:
+        releasetool.commands.common.setup_github_context(ctx)
+
+    if ctx.release_pr is None:
+        releasetool.commands.tag.nodejs.determine_release_pr(ctx)
+
+    releasetool.commands.tag.nodejs.determine_release_tag(ctx)
+    releasetool.commands.tag.nodejs.determine_package_version(ctx)
+
+    # If the release already exists, don't do anything
+    if releasetool.commands.common.release_exists(ctx):
+        click.secho(f"{ctx.release_tag} already exists.", fg="magenta")
+        return ctx
+
+    releasetool.commands.tag.nodejs.get_release_notes(ctx)
+    releasetool.commands.tag.nodejs.create_release(ctx)
+
+    if ctx.interactive:
+        click.secho(f"\\o/ All done!", fg="magenta")
+
+    return ctx


### PR DESCRIPTION
Mostly copied from Node's tag command. I removed the bits that trigger Kokoro jobs, as I believe that isn't required for PHP.