### PR TITLE
Java: relax tag parsing rules from branch name

### DIFF
--- a/releasetool/commands/tag/java.py
+++ b/releasetool/commands/tag/java.py
@@ -47,14 +47,17 @@ def determine_release_pr(ctx: TagContext) -> None:
     ctx.release_pr = pulls[pull_idx - 1]
 
 
+def _parse_release_tag(head_ref: str) -> str:
+    match = re.match(r"release.*-(v\d+\.\d+\.\d+)", head_ref)
+    return match.group(1) if match else None
+
+
 def determine_release_tag(ctx: TagContext) -> None:
     click.secho("> Determining what the release tag should be.", fg="cyan")
     head_ref = ctx.release_pr["head"]["ref"]
-    match = re.match(r"release.*-(v\d+\.\d+\.\d+)", head_ref)
+    ctx.release_tag = _parse_release_tag(head_ref)
 
-    if match is not None:
-        ctx.release_tag = match.group(1)
-    else:
+    if ctx.release_tag is None:
         click.secho(
             "I couldn't determine what the release tag should be from the PR's"
             f"head ref {head_ref}.",

--- a/releasetool/commands/tag/java.py
+++ b/releasetool/commands/tag/java.py
@@ -50,7 +50,7 @@ def determine_release_pr(ctx: TagContext) -> None:
 def determine_release_tag(ctx: TagContext) -> None:
     click.secho("> Determining what the release tag should be.", fg="cyan")
     head_ref = ctx.release_pr["head"]["ref"]
-    match = re.match(r"release-.+-(v\d+\.\d+\.\d+)", head_ref)
+    match = re.match(r"release.*-(v\d+\.\d+\.\d+)", head_ref)
 
     if match is not None:
         ctx.release_tag = match.group(1)

--- a/tests/commands/tag/test_java.py
+++ b/tests/commands/tag/test_java.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from releasetool.commands.tag.java import _parse_release_notes
+from releasetool.commands.tag.java import _parse_release_notes, _parse_release_tag
 
 RELEASETOOL_PR_DESCRIPTION = """
 This pull request was generated using releasetool.
@@ -45,3 +45,13 @@ def test_release_please_release_notes():
     """
     expected = "Some release notes here"
     assert _parse_release_notes(RELEASE_PLEASE_PR_DESCRIPTION) == expected
+
+
+def test_releasetool_release_tag():
+    expected = "v1.2.3"
+    assert _parse_release_tag("release-google-cloud-java-v1.2.3") == expected
+
+
+def test_release_please_release_tag():
+    expected = "v1.2.3"
+    assert _parse_release_tag("release-v1.2.3") == expected


### PR DESCRIPTION
release-please creates the branch: `release-vx.y.z`.