### PR TITLE
Support releasetool tag for dotnet

### DIFF
--- a/releasetool/__main__.py
+++ b/releasetool/__main__.py
@@ -86,7 +86,16 @@ def _detect_language():
     return None
 
 
-_language_choices = ["python", "python-tool", "nodejs", "java", "ruby", "go", "php", "dotnet"]
+_language_choices = [
+    "python",
+    "python-tool",
+    "nodejs",
+    "java",
+    "ruby",
+    "go",
+    "php",
+    "dotnet",
+]
 
 
 def _language_option():

--- a/releasetool/__main__.py
+++ b/releasetool/__main__.py
@@ -32,6 +32,7 @@ import releasetool.commands.tag.nodejs
 import releasetool.commands.tag.java
 import releasetool.commands.tag.php
 import releasetool.commands.tag.ruby
+import releasetool.commands.tag.dotnet
 
 
 class _OptionPromptIfNone(click.Option):
@@ -80,10 +81,12 @@ def _detect_language():
         return "ruby"
     elif os.path.exists("pom.xml") or os.path.exists("build.gradle"):
         return "java"
+    elif os.path.exists("global.json"):
+        return "dotnet"
     return None
 
 
-_language_choices = ["python", "python-tool", "nodejs", "java", "ruby", "go", "php"]
+_language_choices = ["python", "python-tool", "nodejs", "java", "ruby", "go", "php", "dotnet"]
 
 
 def _language_option():
@@ -132,6 +135,8 @@ def tag(language):
         return releasetool.commands.tag.php.tag()
     if language == "ruby":
         return releasetool.commands.tag.ruby.tag()
+    if language == "dotnet":
+        return releasetool.commands.tag.dotnet.tag()
 
 
 @main.command(name="reset-config")

--- a/releasetool/commands/tag/dotnet.py
+++ b/releasetool/commands/tag/dotnet.py
@@ -44,7 +44,7 @@ def determine_release_pr(ctx: TagContext) -> None:
     ctx.release_pr = pulls[pull_idx - 1]
 
 
-def create_releases(ctx: TagContext) -> None:	
+def create_releases(ctx: TagContext) -> None:
     click.secho("> Creating the release.")
 
     commitish = ctx.release_pr["merge_commit_sha"]
@@ -60,7 +60,7 @@ def create_releases(ctx: TagContext) -> None:
                 repository=ctx.upstream_repo,
                 tag_name=tag,
                 target_commitish=commitish,
-                name=tag
+                name=tag,
             )
             click.secho(f"Created release for {tag}")
             pr_comment = pr_comment + f"- Created release for {tag}\n"
@@ -75,13 +75,11 @@ def create_releases(ctx: TagContext) -> None:
     # This isn't a tag, but that's okay - it just needs to be a commitish for
     # Kokoro to build against.
     ctx.release_tag = commitish
-    ctx.kokoro_job_name = (
-        f"cloud-sharp/google-cloud-dotnet/gcp_windows/autorelease"
-    )
+    ctx.kokoro_job_name = f"cloud-sharp/google-cloud-dotnet/gcp_windows/autorelease"
     ctx.github.update_pull_labels(
         ctx.release_pr, add=["autorelease: tagged"], remove=["autorelease: pending"]
     )
-    releasetool.commands.common.publish_via_kokoro(ctx)    
+    releasetool.commands.common.publish_via_kokoro(ctx)
 
 
 # Note: unlike other languages, the .NET libraries may need multiple
@@ -91,7 +89,7 @@ def create_releases(ctx: TagContext) -> None:
 # ctx.release_tag to the commit we've tagged (as all tags will use the same commit).
 def tag(ctx: TagContext = None) -> TagContext:
     if not ctx:
-        ctx = TagContext()        
+        ctx = TagContext()
 
     if ctx.interactive:
         click.secho(f"o/ Hey, {getpass.getuser()}, let's tag a release!", fg="magenta")

--- a/releasetool/commands/tag/dotnet.py
+++ b/releasetool/commands/tag/dotnet.py
@@ -1,0 +1,107 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import getpass
+import re
+
+import click
+
+import releasetool.git
+import releasetool.github
+import releasetool.secrets
+import releasetool.commands.common
+from releasetool.commands.common import TagContext
+
+from typing import List
+
+RELEASE_LINE_PATTERN = r"- Release (.*) version (.*)"
+
+
+def determine_release_pr(ctx: TagContext) -> None:
+    click.secho(
+        "> Let's figure out which pull request corresponds to your release.", fg="cyan"
+    )
+
+    pulls = ctx.github.list_pull_requests(ctx.upstream_repo, state="closed")
+    pulls = [pull for pull in pulls if "release" in pull["title"].lower()][:30]
+
+    click.secho("> Please pick one of the following PRs:\n")
+    for n, pull in enumerate(pulls, 1):
+        print(f"\t{n}: {pull['title']} ({pull['number']})")
+
+    pull_idx = click.prompt("\nWhich one do you want to tag and release?", type=int)
+    ctx.release_pr = pulls[pull_idx - 1]
+
+
+def create_releases(ctx: TagContext) -> None:	
+    click.secho("> Creating the release.")
+
+    commitish = ctx.release_pr["merge_commit_sha"]
+    lines = ctx.release_pr["body"].splitlines()
+    pr_comment = ""
+    for line in lines:
+        match = re.search(RELEASE_LINE_PATTERN, line)
+        if match is not None:
+            package = match.group(1)
+            version = match.group(2)
+            tag = package + "-" + version
+            release = ctx.github.create_release(
+                repository=ctx.upstream_repo,
+                tag_name=tag,
+                target_commitish=commitish,
+                name=tag
+            )
+            click.secho(f"Created release for {tag}")
+            pr_comment = pr_comment + f"- Created release for {tag}\n"
+
+    if pr_comment == "":
+        raise ValueError("No releases found within pull request")
+
+    ctx.github.create_pull_request_comment(
+        ctx.upstream_repo, ctx.release_pr["number"], pr_comment
+    )
+
+    # This isn't a tag, but that's okay - it just needs to be a commitish for
+    # Kokoro to build against.
+    ctx.release_tag = commitish
+    ctx.kokoro_job_name = (
+        f"cloud-sharp/google-cloud-dotnet/gcp_windows/autorelease"
+    )
+    ctx.github.update_pull_labels(
+        ctx.release_pr, add=["autorelease: tagged"], remove=["autorelease: pending"]
+    )
+    releasetool.commands.common.publish_via_kokoro(ctx)    
+
+
+# Note: unlike other languages, the .NET libraries may need multiple
+# tags for a single release PR, usually for dependent APIs, e.g.
+# Google.Cloud.Spanner.Data depending on Google.Cloud.Spanner.V1.
+# We create multiple releases in the create_releases function, and set
+# ctx.release_tag to the commit we've tagged (as all tags will use the same commit).
+def tag(ctx: TagContext = None) -> TagContext:
+    if not ctx:
+        ctx = TagContext()        
+
+    if ctx.interactive:
+        click.secho(f"o/ Hey, {getpass.getuser()}, let's tag a release!", fg="magenta")
+
+    if ctx.github is None:
+        releasetool.commands.common.setup_github_context(ctx)
+
+    if ctx.release_pr is None:
+        determine_release_pr(ctx)
+
+    create_releases(ctx)
+
+    return ctx

--- a/releasetool/commands/tag/dotnet.py
+++ b/releasetool/commands/tag/dotnet.py
@@ -23,8 +23,6 @@ import releasetool.secrets
 import releasetool.commands.common
 from releasetool.commands.common import TagContext
 
-from typing import List
-
 RELEASE_LINE_PATTERN = r"- Release (.*) version (.*)"
 
 
@@ -56,11 +54,12 @@ def create_releases(ctx: TagContext) -> None:
             package = match.group(1)
             version = match.group(2)
             tag = package + "-" + version
-            release = ctx.github.create_release(
+            ctx.github.create_release(
                 repository=ctx.upstream_repo,
                 tag_name=tag,
                 target_commitish=commitish,
                 name=tag,
+                body=f"Package {package} version {version}",
             )
             click.secho(f"Created release for {tag}")
             pr_comment = pr_comment + f"- Created release for {tag}\n"


### PR DESCRIPTION
Our current process is to create tags with a .NET program, which performs extra validation - and can apply multiple tags. We don't want to replicate all that logic in releasetool, so for the moment we'll just assume the releases to create are in the PR.

The process will become:

- Create release PR (that changes the version numbers)
- Merge the release PR
- Run a modified version of the existing .NET tool, that modifies the release PR instead of applying tags directly:
  - Add the "autorelease: pending" label
  - Modify the body of the PR to include the releases to tag
- A cron job will pick up the release PR and run "releasetool tag"
- releasetool will perform the actual tagging and kick off a kokoro build
- kokoro will find the tags on the specified commit and create the NuGet packages and publish docs