### PR TITLE
Tweak repo detection for google-cloud-ruby.

### DIFF
--- a/releasetool/commands/tag/ruby.py
+++ b/releasetool/commands/tag/ruby.py
@@ -79,10 +79,10 @@ def determine_package_name_and_version(ctx: TagContext) -> None:
 
 def get_release_notes(ctx: TagContext) -> None:
     click.secho("> Grabbing the release notes.", fg="cyan")
-    if f"{ctx.origin_user}/{ctx.package_name}" == ctx.upstream_repo:
-        changelog_file = "CHANGELOG.md"
-    else:
+    if "google-cloud-ruby" in ctx.upstream_repo:
         changelog_file = f"{ctx.package_name}/CHANGELOG.md"
+    else:
+        changelog_file = "CHANGELOG.md"
     changelog = ctx.github.get_contents(
         ctx.upstream_repo, changelog_file, ref=ctx.release_pr["merge_commit_sha"]
     ).decode("utf-8")
@@ -152,14 +152,16 @@ def tag(ctx: TagContext = None) -> TagContext:
     create_release(ctx)
 
     job_name = ctx.package_name.split("google-cloud-")[-1]
-    if f"{ctx.origin_user}/{ctx.package_name}" == ctx.upstream_repo:
-        ctx.kokoro_job_name = (
-            f"cloud-devrel/client-libraries/{ctx.package_name}/release"
-        )
-    else:
+
+    if "google-cloud-ruby" in ctx.upstream_repo:
         ctx.kokoro_job_name = (
             f"cloud-devrel/client-libraries/google-cloud-ruby/release/{job_name}"
         )
+    else:
+        ctx.kokoro_job_name = (
+            f"cloud-devrel/client-libraries/{ctx.package_name}/release"
+        )
+
     releasetool.commands.common.publish_via_kokoro(ctx)
 
     if ctx.interactive:


### PR DESCRIPTION
Releasetool appears to be having trouble releasing ruby-style. [Release PR](https://github.com/googleapis/ruby-style/pull/18)

```
Processing Release ruby-style 1.24.0: https://github.com/googleapis/ruby-style/pull/18
> Determining the release tag.
PR head ref is release-ruby-style-v1.24.0
Package name is ruby-style
Package version is 1.24.0
Release tag is ruby-style/v1.24.0
> Determining the package name and version from your release tag.
> Grabbing the release notes.
HTTPError('404 Client Error: Not Found for url: https://api.github.com/repos/googleapis/ruby-style/contents/ruby-style/CHANGELOG.md?ref=05de1cc920d459357cf5621b2f0b9fbc3a4801a2',)
```

If google-cloud-ruby is the only repo with multiple packages, I think this will be less error-prone.