### PR TITLE
fix(python): use conventional commit format for PR title and commit

### DIFF
--- a/releasetool/commands/start/python.py
+++ b/releasetool/commands/start/python.py
@@ -127,10 +127,6 @@ def determine_release_version(ctx: Context) -> None:
 
     if parsed_version == [0, 0, 0]:
         ctx.release_version = "0.1.0"
-        selection = click.prompt(
-            f"The release version is {ctx.release_version}. Enter a version if you'd like something different.", default=ctx.release_version,show_default=True)
-        if selection:
-            ctx.release_version = selection
         return
 
     selection = click.prompt(

--- a/releasetool/commands/start/python.py
+++ b/releasetool/commands/start/python.py
@@ -127,6 +127,10 @@ def determine_release_version(ctx: Context) -> None:
 
     if parsed_version == [0, 0, 0]:
         ctx.release_version = "0.1.0"
+        selection = click.prompt(
+            f"The release version is {ctx.release_version}. Enter a version if you'd like something different.", default=ctx.release_version,show_default=True)
+        if selection:
+            ctx.release_version = selection
         return
 
     selection = click.prompt(
@@ -189,9 +193,9 @@ def create_release_commit(ctx: Context) -> None:
     """Create a release commit."""
     click.secho("> Comitting changes", fg="cyan")
     if ctx.monorepo:
-        commit_msg = f"Release {ctx.package_name} {ctx.release_version}"
+        commit_msg = f"chore({ctx.package_name}): release {ctx.release_version}"
     else:
-        commit_msg = f"Release v{ctx.release_version}"
+        commit_msg = f"chore: release v{ctx.release_version}"
     releasetool.git.commit(["CHANGELOG.md", "setup.py"], commit_msg)
 
 
@@ -209,9 +213,9 @@ def create_release_pr(ctx: Context, autorelease: bool = True) -> None:
         head = f"{ctx.origin_user}:{ctx.release_branch}"
 
     if ctx.monorepo:
-        pr_title = f"Release {ctx.package_name} {ctx.release_version}"
+        pr_title = f"chore({ctx.package_name}): release {ctx.release_version}"
     else:
-        pr_title = f"Release v{ctx.release_version}"
+        pr_title = f"chore: Release v{ctx.release_version}"
 
     ctx.pull_request = ctx.github.create_pull_request(
         ctx.upstream_repo,


### PR DESCRIPTION
So releasetool doesn't make PRs that the linter doesn't like. :)