### PR TITLE
fix(ruby): update non-monorepo ruby job names to reflect kokoro config naming

### DIFF
--- a/releasetool/commands/tag/ruby.py
+++ b/releasetool/commands/tag/ruby.py
@@ -159,7 +159,7 @@ def tag(ctx: TagContext = None) -> TagContext:
         )
     else:
         ctx.kokoro_job_name = (
-            f"cloud-devrel/client-libraries/{ctx.package_name}/release"
+            f"cloud-devrel/client-libraries/{ctx.package_name}/release/{ctx.package_name}"
         )
 
     releasetool.commands.common.publish_via_kokoro(ctx)

--- a/releasetool/commands/tag/ruby.py
+++ b/releasetool/commands/tag/ruby.py
@@ -158,9 +158,7 @@ def tag(ctx: TagContext = None) -> TagContext:
             f"cloud-devrel/client-libraries/google-cloud-ruby/release/{job_name}"
         )
     else:
-        ctx.kokoro_job_name = (
-            f"cloud-devrel/client-libraries/{ctx.package_name}/release/{ctx.package_name}"
-        )
+        ctx.kokoro_job_name = f"cloud-devrel/client-libraries/{ctx.package_name}/release/{ctx.package_name}"
 
     releasetool.commands.common.publish_via_kokoro(ctx)
 


### PR DESCRIPTION
* Update kokoro job name to reflect config location https://github.com/googleapis/signet/blob/master/.kokoro/release/signet.cfg