### PR TITLE
fix: allow first version override

### DIFF
--- a/releasetool/commands/start/go.py
+++ b/releasetool/commands/start/go.py
@@ -130,6 +130,9 @@ def determine_release_version(ctx: Context) -> None:
 
     if parsed_version == [0, 0, 0]:
         ctx.release_version = "0.1.0"
+        if not click.confirm(f"Release {ctx.release_version}?", default=True):
+            version = click.prompt("What version should we release?")
+            ctx.release_version = version
         return
 
     selection = click.prompt(

--- a/releasetool/commands/start/nodejs.py
+++ b/releasetool/commands/start/nodejs.py
@@ -97,6 +97,9 @@ def determine_release_version(ctx: Context) -> None:
 
     if parsed_version == [0, 0, 0]:
         ctx.release_version = "0.1.0"
+        if not click.confirm(f"Release {ctx.release_version}?", default=True):
+            version = click.prompt("What version should we release?")
+            ctx.release_version = version
         return
 
     selection = click.prompt(

--- a/releasetool/commands/start/python.py
+++ b/releasetool/commands/start/python.py
@@ -128,6 +128,10 @@ def determine_release_version(ctx: Context) -> None:
 
     if parsed_version == [0, 0, 0]:
         ctx.release_version = "0.1.0"
+        selection = click.prompt(
+            f"The release version is {ctx.release_version}. Enter a version if you'd like something different.", default=ctx.release_version,show_default=True)
+        if selection:
+            ctx.release_version = selection
         return
 
     selection = click.prompt(

--- a/releasetool/commands/start/python.py
+++ b/releasetool/commands/start/python.py
@@ -128,10 +128,9 @@ def determine_release_version(ctx: Context) -> None:
 
     if parsed_version == [0, 0, 0]:
         ctx.release_version = "0.1.0"
-        selection = click.prompt(
-            f"The release version is {ctx.release_version}. Enter a version if you'd like something different.", default=ctx.release_version,show_default=True)
-        if selection:
-            ctx.release_version = selection
+        if not click.confirm(f"Release {ctx.release_version}?", default=True):
+            version = click.prompt("What version should we release?")
+            ctx.release_version = version
         return
 
     selection = click.prompt(

--- a/releasetool/commands/start/ruby.py
+++ b/releasetool/commands/start/ruby.py
@@ -112,6 +112,9 @@ def determine_release_version(ctx: Context) -> None:
 
     if parsed_version == [0, 0, 0]:
         ctx.release_version = "0.1.0"
+        if not click.confirm(f"Release {ctx.release_version}?", default=True):
+            version = click.prompt("What version should we release?")
+            ctx.release_version = version
         return
 
     selection = click.prompt(


### PR DESCRIPTION
Adds the version override dialog already in Java to `releasetool start` in the other languages.

https://github.com/googleapis/releasetool/blob/51ee1b50bc1023f209765b8ef21ab578989a6454/releasetool/commands/start/java.py#L308-L322

Closes #153 