### PR TITLE
feat: allow doc publication without package publication

### DIFF
--- a/releasetool/commands/publish_reporter.py
+++ b/releasetool/commands/publish_reporter.py
@@ -20,7 +20,7 @@ import re
 from typing import Tuple
 
 import releasetool.github
-import nodejs_docs_only from releasetool.tag.nodejs
+from nodejs_docs_only import releasetool.tag.nodejs
 
 def figure_out_github_token(github_token: str) -> str:
     # This script is designed to run in Kokoro. There's several sources where

--- a/releasetool/commands/publish_reporter.py
+++ b/releasetool/commands/publish_reporter.py
@@ -22,6 +22,7 @@ from typing import Tuple
 import releasetool.github
 from releasetool.commands.tag.nodejs import nodejs_docs_only
 
+
 def figure_out_github_token(github_token: str) -> str:
     # This script is designed to run in Kokoro. There's several sources where
     # the GitHub token could be, and we want to make adding this script easy.

--- a/releasetool/commands/publish_reporter.py
+++ b/releasetool/commands/publish_reporter.py
@@ -20,7 +20,7 @@ import re
 from typing import Tuple
 
 import releasetool.github
-from nodejs_docs_only import releasetool.tag.nodejs
+from releasetool.commands.tag.nodejs import nodejs_docs_only
 
 def figure_out_github_token(github_token: str) -> str:
     # This script is designed to run in Kokoro. There's several sources where

--- a/releasetool/commands/publish_reporter.py
+++ b/releasetool/commands/publish_reporter.py
@@ -20,7 +20,7 @@ import re
 from typing import Tuple
 
 import releasetool.github
-
+import nodejs_docs_only from releasetool.tag.nodejs
 
 def figure_out_github_token(github_token: str) -> str:
     # This script is designed to run in Kokoro. There's several sources where
@@ -118,6 +118,12 @@ def finish(github_token: str, pr: str, status: bool, details: str) -> None:
         owner, repo, number = extract_pr_details(pr)
     except ValueError:
         print("Invalid PR number, returning.")
+        return
+
+    # TODO: we may eventually want to add additional labels, e.g.,
+    # autorelease: docs, autorelease: docs-failed, as of right now our
+    # monitoring detects publication failures (not doc publish failures).
+    if f"{owner}/{repo}" in nodejs_docs_only:
         return
 
     if status:

--- a/releasetool/commands/tag/nodejs.py
+++ b/releasetool/commands/tag/nodejs.py
@@ -24,6 +24,13 @@ import releasetool.secrets
 import releasetool.commands.common
 from releasetool.commands.common import TagContext
 
+# repos that use a GitHub app for publication, but should still have
+# tagging and reference docs uploaded: 
+nodejs_docs_only = [
+    'googleapis/nodejs-datacatalog',
+    'googleapis/nodejs-secret-manager',
+    'googleapis/gaxios'
+]
 
 def determine_release_pr(ctx: TagContext) -> None:
     click.secho(
@@ -70,10 +77,14 @@ def determine_package_version(ctx: TagContext) -> None:
 
 
 def determine_kokoro_job_name(ctx: TagContext) -> None:
-    ctx.kokoro_job_name = (
-        f"cloud-devrel/client-libraries/nodejs/release/{ctx.upstream_repo}/publish"
-    )
-
+    if ctx.upstream_repo in nodejs_docs_only:
+        ctx.kokoro_job_name = (
+            f"cloud-devrel/client-libraries/nodejs/release/{ctx.upstream_repo}/publish"
+        )
+    else:
+        ctx.kokoro_job_name = (
+            f"cloud-devrel/client-libraries/nodejs/release/{ctx.upstream_repo}/docs"
+        )
 
 def get_release_notes(ctx: TagContext) -> None:
     click.secho("> Grabbing the release notes.")

--- a/releasetool/commands/tag/nodejs.py
+++ b/releasetool/commands/tag/nodejs.py
@@ -25,12 +25,13 @@ import releasetool.commands.common
 from releasetool.commands.common import TagContext
 
 # repos that use a GitHub app for publication, but should still have
-# tagging and reference docs uploaded: 
+# tagging and reference docs uploaded:
 nodejs_docs_only = [
-    'googleapis/nodejs-datacatalog',
-    'googleapis/nodejs-secret-manager',
-    'googleapis/gaxios'
+    "googleapis/nodejs-datacatalog",
+    "googleapis/nodejs-secret-manager",
+    "googleapis/gaxios",
 ]
+
 
 def determine_release_pr(ctx: TagContext) -> None:
     click.secho(
@@ -85,6 +86,7 @@ def determine_kokoro_job_name(ctx: TagContext) -> None:
         ctx.kokoro_job_name = (
             f"cloud-devrel/client-libraries/nodejs/release/{ctx.upstream_repo}/docs"
         )
+
 
 def get_release_notes(ctx: TagContext) -> None:
     click.secho("> Grabbing the release notes.")


### PR DESCRIPTION
I think this is a better place to implement the ignore logic I needed, rather than `autorelease`, as I still wanted to kick off the `docs` job.

This PR, instead of ignoring a repo completely, uses `releasetool` for tagging and doc publication, but allows a GitHub app to perform publication for configured repos.