### PR TITLE
fix: allow numerals in Ruby gem names

### DIFF
--- a/releasetool/commands/tag/ruby.py
+++ b/releasetool/commands/tag/ruby.py
@@ -72,7 +72,7 @@ def determine_package_name_and_version(ctx: TagContext) -> None:
     click.secho(
         "> Determining the package name and version from your release tag.", fg="cyan"
     )
-    match = re.match(r"^([a-z-_]+)\/v(\d+.\d+.\d+)$", ctx.release_tag)
+    match = re.match(r"^([a-z0-9-_]+)\/v(\d+.\d+.\d+)$", ctx.release_tag)
     ctx.package_name = match.group(1)
     ctx.release_version = match.group(2)
 


### PR DESCRIPTION
Ruby needs to release gem names with numerals .