### PR TITLE
build: nodejs-recommender uses GitHub app for publication

### DIFF
--- a/releasetool/commands/tag/nodejs.py
+++ b/releasetool/commands/tag/nodejs.py
@@ -28,6 +28,7 @@ from releasetool.commands.common import TagContext
 # tagging and reference docs uploaded:
 nodejs_docs_only = [
     "googleapis/nodejs-datacatalog",
+    "googleapis/nodejs-recommender",
     "googleapis/nodejs-secret-manager",
     "googleapis/gaxios",
 ]


### PR DESCRIPTION
I'm using the GitHub app for publishing new libraries, skipping the step required to add a library to keystore.