### PR TITLE
chore: billing budges publication is managed by publish bot

### DIFF
--- a/releasetool/commands/tag/nodejs.py
+++ b/releasetool/commands/tag/nodejs.py
@@ -27,6 +27,7 @@ from releasetool.commands.common import TagContext
 # repos that use a GitHub app for publication, but should still have
 # tagging and reference docs uploaded:
 nodejs_docs_only = [
+    "googleapis/nodejs-billing-budgets",
     "googleapis/nodejs-datacatalog",
     "googleapis/nodejs-recommender",
     "googleapis/nodejs-secret-manager",


### PR DESCRIPTION
all new libraries are starting to use the publish-bot tool; autorelease is still used for kicking off doc publication.