### PR TITLE
fix(python): fix python changelog detection regex

### DIFF
--- a/releasetool/commands/tag/python.py
+++ b/releasetool/commands/tag/python.py
@@ -91,7 +91,9 @@ def get_release_notes(ctx: TagContext) -> None:
     ).decode("utf-8")
 
     match = re.search(
-        r"#{2,3}[\s\W]+?" + ctx.release_version + r"*?\n(?P<notes>.+?)(\Z|\n#{2,3}\W*?\d)",
+        r"#{2,3}[\s\W]+?"
+        + ctx.release_version
+        + r"*?\n(?P<notes>.+?)(\Z|\n#{2,3}\W*?\d)",
         changelog,
         re.DOTALL | re.MULTILINE,
     )

--- a/releasetool/commands/tag/python.py
+++ b/releasetool/commands/tag/python.py
@@ -91,7 +91,7 @@ def get_release_notes(ctx: TagContext) -> None:
     ).decode("utf-8")
 
     match = re.search(
-        r"#{2,3}[\s\W]+?" + ctx.release_version + "*?\n(?P<notes>.+?)(\Z|\n#{2,3}\W*?\d)",
+        r"#{2,3}[\s\W]+?" + ctx.release_version + r"*?\n(?P<notes>.+?)(\Z|\n#{2,3}\W*?\d)",
         changelog,
         re.DOTALL | re.MULTILINE,
     )

--- a/releasetool/commands/tag/python.py
+++ b/releasetool/commands/tag/python.py
@@ -91,7 +91,7 @@ def get_release_notes(ctx: TagContext) -> None:
     ).decode("utf-8")
 
     match = re.search(
-        rf"#{2,3}[\s\W]+?{ctx.release_version}*?\n(?P<notes>.+?)(\Z|\n#{2,3}\W*?\d)",
+        r"#{2,3}[\s\W]+?" + ctx.release_version + "*?\n(?P<notes>.+?)(\Z|\n#{2,3}\W*?\d)",
         changelog,
         re.DOTALL | re.MULTILINE,
     )


### PR DESCRIPTION
The f-string combined with the raw string wasn't working properly. This glues the version # in with string concatenation instead.