### PR TITLE
chore: nodejs-monitoring-dashboards is handled by wombat

### DIFF
--- a/releasetool/commands/tag/nodejs.py
+++ b/releasetool/commands/tag/nodejs.py
@@ -33,7 +33,7 @@ nodejs_docs_only = [
     "googleapis/nodejs-secret-manager",
     "googleapis/gaxios",
     "googleapis/google-api-nodejs-client",
-    "googleapis/nodejs-monitoring-dashboards"
+    "googleapis/nodejs-monitoring-dashboards",
 ]
 
 

--- a/releasetool/commands/tag/nodejs.py
+++ b/releasetool/commands/tag/nodejs.py
@@ -33,6 +33,7 @@ nodejs_docs_only = [
     "googleapis/nodejs-secret-manager",
     "googleapis/gaxios",
     "googleapis/google-api-nodejs-client",
+    "googleapis/nodejs-monitoring-dashboards"
 ]
 
 


### PR DESCRIPTION
we are using the new publication tooling for this repo.