### PR TITLE
feat: adds Game Servers Node.js library

### DIFF
--- a/releasetool/commands/tag/nodejs.py
+++ b/releasetool/commands/tag/nodejs.py
@@ -29,6 +29,7 @@ from releasetool.commands.common import TagContext
 nodejs_docs_only = [
     "googleapis/nodejs-billing-budgets",
     "googleapis/nodejs-datacatalog",
+    "googleapis/nodejs-game-servers",
     "googleapis/nodejs-recommender",
     "googleapis/nodejs-secret-manager",
     "googleapis/gaxios",


### PR DESCRIPTION
This adds the googleapis/nodejs-game-servers client library to release-tool