### PR TITLE
feat: move all node.js libraries to GitHub app for publication

### DIFF
--- a/releasetool/__main__.py
+++ b/releasetool/__main__.py
@@ -165,13 +165,8 @@ def publish_reporter_start(github_token: str, pr: str):
 @click.option("--pr", envvar="AUTORELEASE_PR", default=None)
 @click.option("--status", type=bool, default=True)
 @click.option("--details", envvar="PUBLISH_DETAILS", default=None)
-@_language_option()
-def publish_reporter_finish(
-    github_token: str, pr: str, status: bool, details: str, language: str
-):
-    releasetool.commands.publish_reporter.finish(
-        github_token, pr, status, details, language
-    )
+def publish_reporter_finish(github_token: str, pr: str, status: bool, details: str):
+    releasetool.commands.publish_reporter.finish(github_token, pr, status, details)
 
 
 @main.command(name="publish-reporter-script")

--- a/releasetool/__main__.py
+++ b/releasetool/__main__.py
@@ -165,8 +165,13 @@ def publish_reporter_start(github_token: str, pr: str):
 @click.option("--pr", envvar="AUTORELEASE_PR", default=None)
 @click.option("--status", type=bool, default=True)
 @click.option("--details", envvar="PUBLISH_DETAILS", default=None)
-def publish_reporter_finish(github_token: str, pr: str, status: bool, details: str):
-    releasetool.commands.publish_reporter.finish(github_token, pr, status, details)
+@_language_option()
+def publish_reporter_finish(
+    github_token: str, pr: str, status: bool, details: str, language: str
+):
+    releasetool.commands.publish_reporter.finish(
+        github_token, pr, status, details, language
+    )
 
 
 @main.command(name="publish-reporter-script")

--- a/releasetool/commands/publish_reporter.py
+++ b/releasetool/commands/publish_reporter.py
@@ -104,9 +104,7 @@ def start(github_token: str, pr: str) -> None:
     gh.create_pull_request_comment(f"{owner}/{repo}", number, message)
 
 
-def finish(
-    github_token: str, pr: str, status: bool, details: str, language: str
-) -> None:
+def finish(github_token: str, pr: str, status: bool, details: str) -> None:
     """Reports the completion of a publication job to GitHub."""
     github_token = figure_out_github_token(github_token)
 
@@ -120,12 +118,6 @@ def finish(
         owner, repo, number = extract_pr_details(pr)
     except ValueError:
         print("Invalid PR number, returning.")
-        return
-
-    # For node.js, publication is handled by a GitHub Application. We still kick
-    # off an autorelease job that publishes docs, but it should not remove
-    # the "autorelease: tagged" label:
-    if language == "nodejs":
         return
 
     if status:

--- a/releasetool/commands/publish_reporter.py
+++ b/releasetool/commands/publish_reporter.py
@@ -20,7 +20,6 @@ import re
 from typing import Tuple
 
 import releasetool.github
-from releasetool.commands.tag.nodejs import nodejs_docs_only
 
 
 def figure_out_github_token(github_token: str) -> str:
@@ -105,7 +104,9 @@ def start(github_token: str, pr: str) -> None:
     gh.create_pull_request_comment(f"{owner}/{repo}", number, message)
 
 
-def finish(github_token: str, pr: str, status: bool, details: str) -> None:
+def finish(
+    github_token: str, pr: str, status: bool, details: str, language: str
+) -> None:
     """Reports the completion of a publication job to GitHub."""
     github_token = figure_out_github_token(github_token)
 
@@ -121,10 +122,10 @@ def finish(github_token: str, pr: str, status: bool, details: str) -> None:
         print("Invalid PR number, returning.")
         return
 
-    # TODO: we may eventually want to add additional labels, e.g.,
-    # autorelease: docs, autorelease: docs-failed, as of right now our
-    # monitoring detects publication failures (not doc publish failures).
-    if f"{owner}/{repo}" in nodejs_docs_only:
+    # For node.js, publication is handled by a GitHub Application. We still kick
+    # off an autorelease job that publishes docs, but it should not remove
+    # the "autorelease: tagged" label:
+    if language == "nodejs":
         return
 
     if status:

--- a/releasetool/commands/tag/nodejs.py
+++ b/releasetool/commands/tag/nodejs.py
@@ -24,20 +24,6 @@ import releasetool.secrets
 import releasetool.commands.common
 from releasetool.commands.common import TagContext
 
-# repos that use a GitHub app for publication, but should still have
-# tagging and reference docs uploaded:
-nodejs_docs_only = [
-    "googleapis/nodejs-billing-budgets",
-    "googleapis/nodejs-datacatalog",
-    "googleapis/nodejs-game-servers",
-    "googleapis/nodejs-recommender",
-    "googleapis/nodejs-secret-manager",
-    "googleapis/gaxios",
-    "googleapis/google-api-nodejs-client",
-    "googleapis/nodejs-monitoring-dashboards",
-    "googleapis/nodejs-bigquery-storage",
-]
-
 
 def determine_release_pr(ctx: TagContext) -> None:
     click.secho(
@@ -84,14 +70,9 @@ def determine_package_version(ctx: TagContext) -> None:
 
 
 def determine_kokoro_job_name(ctx: TagContext) -> None:
-    if ctx.upstream_repo in nodejs_docs_only:
-        ctx.kokoro_job_name = (
-            f"cloud-devrel/client-libraries/nodejs/release/{ctx.upstream_repo}/docs"
-        )
-    else:
-        ctx.kokoro_job_name = (
-            f"cloud-devrel/client-libraries/nodejs/release/{ctx.upstream_repo}/publish"
-        )
+    ctx.kokoro_job_name = (
+        f"cloud-devrel/client-libraries/nodejs/release/{ctx.upstream_repo}/docs"
+    )
 
 
 def get_release_notes(ctx: TagContext) -> None:


### PR DESCRIPTION
I believe this will let us fully swap over to using a GitHub application + wombat dressing room for publication to npm (rather than doing it for a few select libraries).

Should be landed at same time as https://github.com/googleapis/synthtool/pull/425

_I admit I'm procrastinating._