### PR TITLE
fix(publish): google-api-nodejs-client is hitting memory constraints

### DIFF
--- a/releasetool/commands/publish_reporter.py
+++ b/releasetool/commands/publish_reporter.py
@@ -20,6 +20,7 @@ import re
 from typing import Tuple
 
 import releasetool.github
+from releasetool.commands.tag.nodejs import nodejs_docs_only
 
 
 def figure_out_github_token(github_token: str) -> str:
@@ -118,6 +119,12 @@ def finish(github_token: str, pr: str, status: bool, details: str) -> None:
         owner, repo, number = extract_pr_details(pr)
     except ValueError:
         print("Invalid PR number, returning.")
+        return
+
+    # TODO: we may eventually want to add additional labels, e.g.,
+    # autorelease: docs, autorelease: docs-failed, as of right now our
+    # monitoring detects publication failures (not doc publish failures).
+    if f"{owner}/{repo}" in nodejs_docs_only:
         return
 
     if status:

--- a/releasetool/commands/publish_reporter.py
+++ b/releasetool/commands/publish_reporter.py
@@ -20,7 +20,6 @@ import re
 from typing import Tuple
 
 import releasetool.github
-from releasetool.commands.tag.nodejs import nodejs_docs_only
 
 
 def figure_out_github_token(github_token: str) -> str:
@@ -119,12 +118,6 @@ def finish(github_token: str, pr: str, status: bool, details: str) -> None:
         owner, repo, number = extract_pr_details(pr)
     except ValueError:
         print("Invalid PR number, returning.")
-        return
-
-    # TODO: we may eventually want to add additional labels, e.g.,
-    # autorelease: docs, autorelease: docs-failed, as of right now our
-    # monitoring detects publication failures (not doc publish failures).
-    if f"{owner}/{repo}" in nodejs_docs_only:
         return
 
     if status:

--- a/releasetool/commands/tag/nodejs.py
+++ b/releasetool/commands/tag/nodejs.py
@@ -24,6 +24,20 @@ import releasetool.secrets
 import releasetool.commands.common
 from releasetool.commands.common import TagContext
 
+# repos that use a GitHub app for publication, but should still have
+# tagging and reference docs uploaded:
+nodejs_docs_only = [
+    "googleapis/nodejs-billing-budgets",
+    "googleapis/nodejs-datacatalog",
+    "googleapis/nodejs-game-servers",
+    "googleapis/nodejs-recommender",
+    "googleapis/nodejs-secret-manager",
+    "googleapis/gaxios",
+    "googleapis/google-api-nodejs-client",
+    "googleapis/nodejs-monitoring-dashboards",
+    "googleapis/nodejs-bigquery-storage",
+]
+
 
 def determine_release_pr(ctx: TagContext) -> None:
     click.secho(
@@ -70,9 +84,14 @@ def determine_package_version(ctx: TagContext) -> None:
 
 
 def determine_kokoro_job_name(ctx: TagContext) -> None:
-    ctx.kokoro_job_name = (
-        f"cloud-devrel/client-libraries/nodejs/release/{ctx.upstream_repo}/docs"
-    )
+    if ctx.upstream_repo in nodejs_docs_only:
+        ctx.kokoro_job_name = (
+            f"cloud-devrel/client-libraries/nodejs/release/{ctx.upstream_repo}/docs"
+        )
+    else:
+        ctx.kokoro_job_name = (
+            f"cloud-devrel/client-libraries/nodejs/release/{ctx.upstream_repo}/publish"
+        )
 
 
 def get_release_notes(ctx: TagContext) -> None:

--- a/releasetool/commands/tag/nodejs.py
+++ b/releasetool/commands/tag/nodejs.py
@@ -24,18 +24,9 @@ import releasetool.secrets
 import releasetool.commands.common
 from releasetool.commands.common import TagContext
 
-# repos that use a GitHub app for publication, but should still have
-# tagging and reference docs uploaded:
-nodejs_docs_only = [
-    "googleapis/nodejs-billing-budgets",
-    "googleapis/nodejs-datacatalog",
-    "googleapis/nodejs-game-servers",
-    "googleapis/nodejs-recommender",
-    "googleapis/nodejs-secret-manager",
-    "googleapis/gaxios",
+# repos that still use kokoro for publication:
+nodejs_handle_publish = [
     "googleapis/google-api-nodejs-client",
-    "googleapis/nodejs-monitoring-dashboards",
-    "googleapis/nodejs-bigquery-storage",
 ]
 
 
@@ -84,13 +75,13 @@ def determine_package_version(ctx: TagContext) -> None:
 
 
 def determine_kokoro_job_name(ctx: TagContext) -> None:
-    if ctx.upstream_repo in nodejs_docs_only:
+    if ctx.upstream_repo in nodejs_handle_publish:
         ctx.kokoro_job_name = (
-            f"cloud-devrel/client-libraries/nodejs/release/{ctx.upstream_repo}/docs"
+            f"cloud-devrel/client-libraries/nodejs/release/{ctx.upstream_repo}/publish"
         )
     else:
         ctx.kokoro_job_name = (
-            f"cloud-devrel/client-libraries/nodejs/release/{ctx.upstream_repo}/publish"
+            f"cloud-devrel/client-libraries/nodejs/release/{ctx.upstream_repo}/docs"
         )
 
 


### PR DESCRIPTION
In the short term, I believe we might need to use kokoro-based publication for (which is bumping into memory constraint issues compiling in cloud functions).