### PR TITLE
fix: Don't match names with spaces in for .NET packages

### DIFF
--- a/releasetool/commands/common.py
+++ b/releasetool/commands/common.py
@@ -127,7 +127,7 @@ def setup_github_context(
 
 
 def edit_release_notes(ctx: GitHubContext) -> None:
-    click.secho(f"> Opening your editor to finalize release notes.", fg="cyan")
+    click.secho("> Opening your editor to finalize release notes.", fg="cyan")
     release_notes = (
         datetime.datetime.now(datetime.timezone.utc)
         .astimezone(tz.gettz("US/Pacific"))
@@ -175,7 +175,7 @@ def publish_via_kokoro(ctx: TagContext) -> None:
         pyperclip.copy(ctx.release_tag)
 
         click.secho(
-            f"> Trigger the Kokoro build with the commitish below to publish to PyPI. The commitish has been copied to the clipboard.",
+            "> Trigger the Kokoro build with the commitish below to publish to PyPI. The commitish has been copied to the clipboard.",
             fg="cyan",
         )
 

--- a/releasetool/commands/publish_reporter.py
+++ b/releasetool/commands/publish_reporter.py
@@ -99,7 +99,7 @@ def start(github_token: str, pr: str) -> None:
     if build_url:
         message = f"The release build has started, the log can be viewed [here]({build_url}). :sunflower:"
     else:
-        message = f"The release build has started, but the build log URL could not be determined. :broken_heart:"
+        message = "The release build has started, but the build log URL could not be determined. :broken_heart:"
 
     gh.create_pull_request_comment(f"{owner}/{repo}", number, message)
 

--- a/releasetool/commands/start/go.py
+++ b/releasetool/commands/start/go.py
@@ -116,13 +116,13 @@ def determine_last_release(ctx: Context) -> None:
 def gather_changes(ctx: Context) -> None:
     click.secho(f"> Gathering changes since {ctx.last_release_version}", fg="cyan")
     ctx.changes = releasetool.git.summary_log(
-        from_=ctx.last_release_committish, to=f"origin/master"
+        from_=ctx.last_release_committish, to="origin/master"
     )
     click.secho(f"Cool, {len(ctx.changes)} changes found.")
 
 
 def determine_release_version(ctx: Context) -> None:
-    click.secho(f"> Now it's time to pick a release version!", fg="cyan")
+    click.secho("> Now it's time to pick a release version!", fg="cyan")
     release_notes = textwrap.indent(ctx.release_notes, "\t")
     click.secho(f"Here's the release notes you wrote:\n\n{release_notes}\n")
 
@@ -190,13 +190,13 @@ def create_release_commit(ctx: Context) -> None:
 
 
 def create_release_cl(ctx: Context) -> None:
-    click.secho(f"> Creating release CL.", fg="cyan")
+    click.secho("> Creating release CL.", fg="cyan")
     revs = click.prompt("reviewers (comma-separated)", default="deklerk,jba")
     subprocess.check_output(["git", "codereview", "mail", "-r", revs, "HEAD"])
 
 
 def edit_release_notes(ctx: Context) -> None:
-    click.secho(f"> Opening your editor to finalize release notes.", fg="cyan")
+    click.secho("> Opening your editor to finalize release notes.", fg="cyan")
     release_notes = (
         datetime.datetime.now(datetime.timezone.utc)
         .astimezone(tz.gettz("US/Pacific"))
@@ -242,4 +242,4 @@ def start() -> None:
     create_release_commit(ctx)
     create_release_cl(ctx)
 
-    click.secho(f"\\o/ All done!", fg="magenta")
+    click.secho("\\o/ All done!", fg="magenta")

--- a/releasetool/commands/start/java.py
+++ b/releasetool/commands/start/java.py
@@ -307,7 +307,7 @@ def gather_changes(ctx: Context) -> None:
 
 def determine_release_version(ctx: Context) -> None:
     """Determines the release version for release tagging"""
-    click.secho(f"> Now it's time to pick a release version!", fg="cyan")
+    click.secho("> Now it's time to pick a release version!", fg="cyan")
     release_notes = textwrap.indent(ctx.release_notes, "\t")
     click.secho(f"Here's the release notes you wrote:\n\n{release_notes}\n")
 
@@ -408,4 +408,4 @@ def start() -> None:
     create_release_branch(ctx)
     create_release_pr(ctx)
 
-    click.secho(f"\\o/ All done!", fg="magenta")
+    click.secho("\\o/ All done!", fg="magenta")

--- a/releasetool/commands/start/nodejs.py
+++ b/releasetool/commands/start/nodejs.py
@@ -89,7 +89,7 @@ def gather_changes(ctx: Context) -> None:
 
 
 def determine_release_version(ctx: Context) -> None:
-    click.secho(f"> Now it's time to pick a release version!", fg="cyan")
+    click.secho("> Now it's time to pick a release version!", fg="cyan")
     release_notes = textwrap.indent(ctx.release_notes, "\t")
     click.secho(f"Here's the release notes you wrote:\n\n{release_notes}\n")
 
@@ -186,7 +186,7 @@ def push_release_branch(ctx: Context) -> None:
 
 
 def create_release_pr(ctx: Context, autorelease: bool = True) -> None:
-    click.secho(f"> Creating release pull request.", fg="cyan")
+    click.secho("> Creating release pull request.", fg="cyan")
 
     if ctx.upstream_repo == ctx.origin_repo:
         head = ctx.release_branch
@@ -228,4 +228,4 @@ def start() -> None:
     # TODO: Confirm?
     create_release_pr(ctx)
 
-    click.secho(f"\\o/ All done!", fg="magenta")
+    click.secho("\\o/ All done!", fg="magenta")

--- a/releasetool/commands/start/python.py
+++ b/releasetool/commands/start/python.py
@@ -111,7 +111,7 @@ def determine_last_release(ctx: Context) -> None:
 def gather_changes(ctx: Context) -> None:
     click.secho(f"> Gathering changes since {ctx.last_release_version}", fg="cyan")
     ctx.changes = releasetool.git.summary_log(
-        from_=ctx.last_release_committish, to=f"master"
+        from_=ctx.last_release_committish, to="master"
     )
     ctx.changes = [
         ctx.github.link_pull_request(c, ctx.upstream_repo) for c in ctx.changes
@@ -120,7 +120,7 @@ def gather_changes(ctx: Context) -> None:
 
 
 def determine_release_version(ctx: Context) -> None:
-    click.secho(f"> Now it's time to pick a release version!", fg="cyan")
+    click.secho("> Now it's time to pick a release version!", fg="cyan")
     release_notes = textwrap.indent(ctx.release_notes, "\t")
     click.secho(f"Here's the release notes you wrote:\n\n{release_notes}\n")
 
@@ -205,7 +205,7 @@ def push_release_branch(ctx: Context) -> None:
 
 
 def create_release_pr(ctx: Context, autorelease: bool = True) -> None:
-    click.secho(f"> Creating release pull request.", fg="cyan")
+    click.secho("> Creating release pull request.", fg="cyan")
 
     if ctx.upstream_repo == ctx.origin_repo:
         head = ctx.release_branch
@@ -254,4 +254,4 @@ def start() -> None:
     push_release_branch(ctx)
     create_release_pr(ctx)
 
-    click.secho(f"\\o/ All done!", fg="magenta")
+    click.secho("\\o/ All done!", fg="magenta")

--- a/releasetool/commands/start/python_tool.py
+++ b/releasetool/commands/start/python_tool.py
@@ -59,4 +59,4 @@ def start() -> None:
     # TODO: Confirm?
     releasetool.commands.start.python.create_release_pr(ctx)
 
-    click.secho(f"\\o/ All done!", fg="magenta")
+    click.secho("\\o/ All done!", fg="magenta")

--- a/releasetool/commands/start/ruby.py
+++ b/releasetool/commands/start/ruby.py
@@ -55,7 +55,7 @@ class Context(releasetool.commands.common.GitHubContext):
 def determine_package_name(ctx: Context) -> None:
     click.secho("> Figuring out the package name.", fg="cyan")
     ctx.package_name = os.path.basename(os.getcwd())
-    click.secho("Looks like we're releasing {ctx.package_name}.")
+    click.secho(f"Looks like we're releasing {ctx.package_name}.")
 
 
 def gather_tags(ctx: Context) -> None:

--- a/releasetool/commands/start/ruby.py
+++ b/releasetool/commands/start/ruby.py
@@ -55,7 +55,7 @@ class Context(releasetool.commands.common.GitHubContext):
 def determine_package_name(ctx: Context) -> None:
     click.secho("> Figuring out the package name.", fg="cyan")
     ctx.package_name = os.path.basename(os.getcwd())
-    click.secho(f"Looks like we're releasing {ctx.package_name}.")
+    click.secho("Looks like we're releasing {ctx.package_name}.")
 
 
 def gather_tags(ctx: Context) -> None:
@@ -96,7 +96,7 @@ def gather_changes(ctx: Context) -> None:
 
 
 def edit_release_notes(ctx: Context) -> None:
-    click.secho(f"> Opening your editor to finalize release notes.", fg="cyan")
+    click.secho("> Opening your editor to finalize release notes.", fg="cyan")
     release_notes = "\n".join(change.strip() for change in ctx.changes)
     ctx.release_notes = releasetool.filehelpers.open_editor_with_tempfile(
         release_notes, "release-notes.md"
@@ -104,7 +104,7 @@ def edit_release_notes(ctx: Context) -> None:
 
 
 def determine_release_version(ctx: Context) -> None:
-    click.secho(f"> Now it's time to pick a release version!", fg="cyan")
+    click.secho("> Now it's time to pick a release version!", fg="cyan")
     release_notes = textwrap.indent(ctx.release_notes, "\t")
     click.secho(f"Here's the release notes you wrote:\n\n{release_notes}\n")
 
@@ -198,7 +198,7 @@ def push_release_branch(ctx: Context) -> None:
 
 
 def create_release_pr(ctx: Context, autorelease: bool = True) -> None:
-    click.secho(f"> Creating release pull request.", fg="cyan")
+    click.secho("> Creating release pull request.", fg="cyan")
 
     if ctx.upstream_repo == ctx.origin_repo:
         head = ctx.release_branch
@@ -255,4 +255,4 @@ def start() -> None:
     create_release_pr(ctx)
     checkout_master()
 
-    click.secho(f"\\o/ All done!", fg="magenta")
+    click.secho("\\o/ All done!", fg="magenta")

--- a/releasetool/commands/tag/dotnet.py
+++ b/releasetool/commands/tag/dotnet.py
@@ -82,7 +82,7 @@ def create_releases(ctx: TagContext) -> None:
     # This isn't a tag, but that's okay - it just needs to be a commitish for
     # Kokoro to build against.
     ctx.release_tag = commitish
-    ctx.kokoro_job_name = f"cloud-sharp/google-cloud-dotnet/gcp_windows/autorelease"
+    ctx.kokoro_job_name = "cloud-sharp/google-cloud-dotnet/gcp_windows/autorelease"
     ctx.github.update_pull_labels(
         ctx.release_pr, add=["autorelease: tagged"], remove=["autorelease: pending"]
     )

--- a/releasetool/commands/tag/dotnet.py
+++ b/releasetool/commands/tag/dotnet.py
@@ -23,7 +23,7 @@ import releasetool.secrets
 import releasetool.commands.common
 from releasetool.commands.common import TagContext
 
-RELEASE_LINE_PATTERN = r"^(?:- )?Release (.*) version (.*)"
+RELEASE_LINE_PATTERN = r"^(?:- )?Release ([^ ]*) version (.*)"
 
 
 def determine_release_pr(ctx: TagContext) -> None:

--- a/releasetool/commands/tag/java.py
+++ b/releasetool/commands/tag/java.py
@@ -145,6 +145,6 @@ def tag(ctx: TagContext = None) -> TagContext:
     create_release(ctx)
 
     if ctx.interactive:
-        click.secho(f"\\o/ All done!", fg="magenta")
+        click.secho("\\o/ All done!", fg="magenta")
 
     return ctx

--- a/releasetool/commands/tag/nodejs.py
+++ b/releasetool/commands/tag/nodejs.py
@@ -176,6 +176,6 @@ def tag(ctx: TagContext = None) -> TagContext:
     releasetool.commands.common.publish_via_kokoro(ctx)
 
     if ctx.interactive:
-        click.secho(f"\\o/ All done!", fg="magenta")
+        click.secho("\\o/ All done!", fg="magenta")
 
     return ctx

--- a/releasetool/commands/tag/php.py
+++ b/releasetool/commands/tag/php.py
@@ -33,6 +33,6 @@ def tag(ctx: TagContext = None) -> TagContext:
     releasetool.commands.tag.nodejs.create_release(ctx)
 
     if ctx.interactive:
-        click.secho(f"\\o/ All done!", fg="magenta")
+        click.secho("\\o/ All done!", fg="magenta")
 
     return ctx

--- a/releasetool/commands/tag/python.py
+++ b/releasetool/commands/tag/python.py
@@ -163,6 +163,6 @@ def tag(ctx: TagContext = None) -> TagContext:
     releasetool.commands.common.publish_via_kokoro(ctx)
 
     if ctx.interactive:
-        click.secho(f"\\o/ All done!", fg="magenta")
+        click.secho("\\o/ All done!", fg="magenta")
 
     return ctx

--- a/releasetool/commands/tag/python_tool.py
+++ b/releasetool/commands/tag/python_tool.py
@@ -25,7 +25,7 @@ from releasetool.commands.tag import python
 def get_release_notes(ctx: TagContext) -> None:
     click.secho("> Grabbing the release notes.")
     changelog = ctx.github.get_contents(
-        ctx.upstream_repo, f"CHANGELOG.md", ref=ctx.release_pr["merge_commit_sha"]
+        ctx.upstream_repo, "CHANGELOG.md", ref=ctx.release_pr["merge_commit_sha"]
     ).decode("utf-8")
 
     match = re.search(
@@ -91,6 +91,6 @@ def tag(ctx: TagContext = None) -> TagContext:
     releasetool.commands.common.publish_via_kokoro(ctx)
 
     if ctx.interactive:
-        click.secho(f"\\o/ All done!", fg="magenta")
+        click.secho("\\o/ All done!", fg="magenta")
 
     return ctx

--- a/releasetool/commands/tag/ruby.py
+++ b/releasetool/commands/tag/ruby.py
@@ -165,7 +165,7 @@ def tag(ctx: TagContext = None) -> TagContext:
     releasetool.commands.common.publish_via_kokoro(ctx)
 
     if ctx.interactive:
-        click.secho(f"\\o/ All done!", fg="magenta")
+        click.secho("\\o/ All done!", fg="magenta")
 
     branch = ctx.release_pr["head"]["ref"]
 


### PR DESCRIPTION
This caused a problem with a PR with a title of "Release Firestore libraries version 2.0.0"