### PR TITLE
build: use kokoro for publishing logging

### DIFF
--- a/releasetool/commands/tag/nodejs.py
+++ b/releasetool/commands/tag/nodejs.py
@@ -27,6 +27,7 @@ from releasetool.commands.common import TagContext
 # repos that still use kokoro for publication:
 nodejs_handle_publish = [
     "googleapis/google-api-nodejs-client",
+    "googleapis/nodejs-logging"
 ]
 
 

--- a/releasetool/commands/tag/nodejs.py
+++ b/releasetool/commands/tag/nodejs.py
@@ -27,7 +27,7 @@ from releasetool.commands.common import TagContext
 # repos that still use kokoro for publication:
 nodejs_handle_publish = [
     "googleapis/google-api-nodejs-client",
-    "googleapis/nodejs-logging"
+    "googleapis/nodejs-logging",
 ]
 
 


### PR DESCRIPTION
Using a cloud function for publication is failing on some APIs.