### PR TITLE
feat: add support for GitHub  JWT auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,7 @@ venv.bak/
 # mypy
 .mypy_cache/
 
+app
+installation
+pem
+

--- a/.gitignore
+++ b/.gitignore
@@ -109,4 +109,3 @@ venv.bak/
 app
 installation
 pem
-

--- a/releasetool/__main__.py
+++ b/releasetool/__main__.py
@@ -159,7 +159,13 @@ def reset_config():
 @click.option("--app_id_path", envvar="APP_ID", default=None)
 @click.option("--installation_path", envvar="INSTALLATION", default=None)
 @click.option("--private_key_path", envvar="GITHUB_PRIVATE_KEY", default=None)
-def publish_reporter_start(github_token: str, pr: str, app_id_path: str, installation_path: str, private_key_path: str):
+def publish_reporter_start(
+    github_token: str,
+    pr: str,
+    app_id_path: str,
+    installation_path: str,
+    private_key_path: str,
+):
     if app_id_path:
         github_token = github_jwt_dict(app_id_path, installation_path, private_key_path)
     releasetool.commands.publish_reporter.start(github_token, pr)
@@ -173,7 +179,15 @@ def publish_reporter_start(github_token: str, pr: str, app_id_path: str, install
 @click.option("--app_id_path", envvar="APP_ID", default=None)
 @click.option("--installation_path", envvar="INSTALLATION", default=None)
 @click.option("--private_key_path", envvar="GITHUB_PRIVATE_KEY", default=None)
-def publish_reporter_finish(github_token: str, pr: str, status: bool, details: str, app_id_path: str, installation_path: str, private_key_path: str):
+def publish_reporter_finish(
+    github_token: str,
+    pr: str,
+    status: bool,
+    details: str,
+    app_id_path: str,
+    installation_path: str,
+    private_key_path: str,
+):
     if app_id_path:
         github_token = github_jwt_dict(app_id_path, installation_path, private_key_path)
     releasetool.commands.publish_reporter.finish(github_token, pr, status, details)
@@ -181,9 +195,9 @@ def publish_reporter_finish(github_token: str, pr: str, status: bool, details: s
 
 def github_jwt_dict(app_id_path: str, installation_path: str, private_key_path: str):
     return {
-        "app_id": open(app_id_path, 'r').read(),
-        "installation": open(installation_path, 'r').read(),
-        "private_key": open(private_key_path, 'r').read()
+        "app_id": open(app_id_path, "r").read(),
+        "installation": open(installation_path, "r").read(),
+        "private_key": open(private_key_path, "r").read(),
     }
 
 

--- a/releasetool/__main__.py
+++ b/releasetool/__main__.py
@@ -194,6 +194,9 @@ def publish_reporter_finish(
 
 
 def github_jwt_dict(app_id_path: str, installation_id_path: str, private_key_path: str):
+    """An app_id, installation_id, and private_key may be provided, rather
+    than a github_token. This dictionary of values is passed to publish_reporter
+    which exchanges them for a JWT."""
     return {
         "app_id": open(app_id_path, "r").read(),
         "installation_id": open(installation_id_path, "r").read(),

--- a/releasetool/__main__.py
+++ b/releasetool/__main__.py
@@ -156,9 +156,9 @@ def reset_config():
 @main.command(name="publish-reporter-start")
 @click.option("--github_token", envvar="GITHUB_TOKEN", default=None)
 @click.option("--pr", envvar="AUTORELEASE_PR", default=None)
-@click.option("--app_id_path", envvar="APP_ID", default=None)
-@click.option("--installation_path", envvar="INSTALLATION", default=None)
-@click.option("--private_key_path", envvar="GITHUB_PRIVATE_KEY", default=None)
+@click.option("--app_id_path", envvar="APP_ID_PATH", default=None)
+@click.option("--installation_path", envvar="INSTALLATION_PATH", default=None)
+@click.option("--private_key_path", envvar="GITHUB_PRIVATE_KEY_PATH", default=None)
 def publish_reporter_start(
     github_token: str,
     pr: str,
@@ -176,9 +176,9 @@ def publish_reporter_start(
 @click.option("--pr", envvar="AUTORELEASE_PR", default=None)
 @click.option("--status", type=bool, default=True)
 @click.option("--details", envvar="PUBLISH_DETAILS", default=None)
-@click.option("--app_id_path", envvar="APP_ID", default=None)
-@click.option("--installation_path", envvar="INSTALLATION", default=None)
-@click.option("--private_key_path", envvar="GITHUB_PRIVATE_KEY", default=None)
+@click.option("--app_id_path", envvar="APP_ID_PATH", default=None)
+@click.option("--installation_path", envvar="INSTALLATION_PATH", default=None)
+@click.option("--private_key_path", envvar="GITHUB_PRIVATE_KEY_PATH", default=None)
 def publish_reporter_finish(
     github_token: str,
     pr: str,

--- a/releasetool/__main__.py
+++ b/releasetool/__main__.py
@@ -157,17 +157,17 @@ def reset_config():
 @click.option("--github_token", envvar="GITHUB_TOKEN", default=None)
 @click.option("--pr", envvar="AUTORELEASE_PR", default=None)
 @click.option("--app_id_path", envvar="APP_ID_PATH", default=None)
-@click.option("--installation_path", envvar="INSTALLATION_PATH", default=None)
+@click.option("--installation_id_path", envvar="INSTALLATION_ID_PATH", default=None)
 @click.option("--private_key_path", envvar="GITHUB_PRIVATE_KEY_PATH", default=None)
 def publish_reporter_start(
     github_token: str,
     pr: str,
     app_id_path: str,
-    installation_path: str,
+    installation_id_path: str,
     private_key_path: str,
 ):
     if app_id_path:
-        github_token = github_jwt_dict(app_id_path, installation_path, private_key_path)
+        github_token = github_jwt_dict(app_id_path, installation_id_path, private_key_path)
     releasetool.commands.publish_reporter.start(github_token, pr)
 
 
@@ -177,7 +177,7 @@ def publish_reporter_start(
 @click.option("--status", type=bool, default=True)
 @click.option("--details", envvar="PUBLISH_DETAILS", default=None)
 @click.option("--app_id_path", envvar="APP_ID_PATH", default=None)
-@click.option("--installation_path", envvar="INSTALLATION_PATH", default=None)
+@click.option("--installation_id_path", envvar="INSTALLATION_ID_PATH", default=None)
 @click.option("--private_key_path", envvar="GITHUB_PRIVATE_KEY_PATH", default=None)
 def publish_reporter_finish(
     github_token: str,
@@ -185,18 +185,18 @@ def publish_reporter_finish(
     status: bool,
     details: str,
     app_id_path: str,
-    installation_path: str,
+    installation_id_path: str,
     private_key_path: str,
 ):
     if app_id_path:
-        github_token = github_jwt_dict(app_id_path, installation_path, private_key_path)
+        github_token = github_jwt_dict(app_id_path, installation_id_path, private_key_path)
     releasetool.commands.publish_reporter.finish(github_token, pr, status, details)
 
 
-def github_jwt_dict(app_id_path: str, installation_path: str, private_key_path: str):
+def github_jwt_dict(app_id_path: str, installation_id_path: str, private_key_path: str):
     return {
         "app_id": open(app_id_path, "r").read(),
-        "installation": open(installation_path, "r").read(),
+        "installation_id": open(installation_id_path, "r").read(),
         "private_key": open(private_key_path, "r").read(),
     }
 

--- a/releasetool/__main__.py
+++ b/releasetool/__main__.py
@@ -167,7 +167,9 @@ def publish_reporter_start(
     private_key_path: str,
 ):
     if app_id_path:
-        github_token = github_jwt_dict(app_id_path, installation_id_path, private_key_path)
+        github_token = github_jwt_dict(
+            app_id_path, installation_id_path, private_key_path
+        )
     releasetool.commands.publish_reporter.start(github_token, pr)
 
 
@@ -189,7 +191,9 @@ def publish_reporter_finish(
     private_key_path: str,
 ):
     if app_id_path:
-        github_token = github_jwt_dict(app_id_path, installation_id_path, private_key_path)
+        github_token = github_jwt_dict(
+            app_id_path, installation_id_path, private_key_path
+        )
     releasetool.commands.publish_reporter.finish(github_token, pr, status, details)
 
 

--- a/releasetool/__main__.py
+++ b/releasetool/__main__.py
@@ -156,7 +156,12 @@ def reset_config():
 @main.command(name="publish-reporter-start")
 @click.option("--github_token", envvar="GITHUB_TOKEN", default=None)
 @click.option("--pr", envvar="AUTORELEASE_PR", default=None)
-def publish_reporter_start(github_token: str, pr: str):
+@click.option("--app_id_path", envvar="APP_ID", default=None)
+@click.option("--installation_path", envvar="INSTALLATION", default=None)
+@click.option("--private_key_path", envvar="GITHUB_PRIVATE_KEY", default=None)
+def publish_reporter_start(github_token: str, pr: str, app_id_path: str, installation_path: str, private_key_path: str):
+    if app_id_path:
+        github_token = github_jwt_dict(app_id_path, installation_path, private_key_path)
     releasetool.commands.publish_reporter.start(github_token, pr)
 
 
@@ -165,8 +170,21 @@ def publish_reporter_start(github_token: str, pr: str):
 @click.option("--pr", envvar="AUTORELEASE_PR", default=None)
 @click.option("--status", type=bool, default=True)
 @click.option("--details", envvar="PUBLISH_DETAILS", default=None)
-def publish_reporter_finish(github_token: str, pr: str, status: bool, details: str):
+@click.option("--app_id_path", envvar="APP_ID", default=None)
+@click.option("--installation_path", envvar="INSTALLATION", default=None)
+@click.option("--private_key_path", envvar="GITHUB_PRIVATE_KEY", default=None)
+def publish_reporter_finish(github_token: str, pr: str, status: bool, details: str, app_id_path: str, installation_path: str, private_key_path: str):
+    if app_id_path:
+        github_token = github_jwt_dict(app_id_path, installation_path, private_key_path)
     releasetool.commands.publish_reporter.finish(github_token, pr, status, details)
+
+
+def github_jwt_dict(app_id_path: str, installation_path: str, private_key_path: str):
+    return {
+        "app_id": open(app_id_path, 'r').read(),
+        "installation": open(installation_path, 'r').read(),
+        "private_key": open(private_key_path, 'r').read()
+    }
 
 
 @main.command(name="publish-reporter-script")

--- a/releasetool/commands/common.py
+++ b/releasetool/commands/common.py
@@ -103,7 +103,7 @@ def setup_github_context(
         "Please provide your GitHub API token with write:repo_hook and "
         "public_repo (https://github.com/settings/tokens)",
     )
-    ctx.github = releasetool.github.GitHub(github_token)
+    ctx.github = releasetool.github.GitHub(releasetool.github.GitHubToken(github_token))
 
     _determine_origin(ctx)
     _determine_upstream(ctx, owners)

--- a/releasetool/commands/common.py
+++ b/releasetool/commands/common.py
@@ -103,7 +103,8 @@ def setup_github_context(
         "Please provide your GitHub API token with write:repo_hook and "
         "public_repo (https://github.com/settings/tokens)",
     )
-    ctx.github = releasetool.github.GitHub(releasetool.github.GitHubToken(github_token))
+
+    ctx.github = releasetool.github.GitHub(releasetool.github.GitHubToken(github_token, 'Bearer'))
 
     _determine_origin(ctx)
     _determine_upstream(ctx, owners)

--- a/releasetool/commands/common.py
+++ b/releasetool/commands/common.py
@@ -104,7 +104,9 @@ def setup_github_context(
         "public_repo (https://github.com/settings/tokens)",
     )
 
-    ctx.github = releasetool.github.GitHub(releasetool.github.GitHubToken(github_token, 'Bearer'))
+    ctx.github = releasetool.github.GitHub(
+        releasetool.github.GitHubToken(github_token, "Bearer")
+    )
 
     _determine_origin(ctx)
     _determine_upstream(ctx, owners)

--- a/releasetool/commands/publish_reporter.py
+++ b/releasetool/commands/publish_reporter.py
@@ -73,23 +73,23 @@ def extract_pr_details(pr) -> Tuple[str, str, str]:
     return match.group("owner"), match.group("repo"), match.group("number")
 
 
-def start(github_token: Union[str, dict], pr: str) -> None:
+def start(github_token_raw: Union[str, dict], pr: str) -> None:
     """Reports the start of a publication job to GitHub."""
     # If we are passed a dictionary for github_token, assume we are
     # retrieveing a JWT, and do not use magic proxy:
     use_proxy = True
-    if type(github_token) is dict:
+    if type(github_token_raw) is dict:
         use_proxy = False
+        github_token = releasetool.github.GitHubToken.token_from_dict(cast(dict, github_token_raw))
     else:
-        github_token = figure_out_github_token(cast(str, github_token))
+        github_token_raw = figure_out_github_token(cast(str, github_token))
+        github_token = releasetool.github.GitHubToken(github_token_raw, 'Bearer')
 
     if not github_token or not pr:
         print("No github token or PR specified to report status to, returning.")
         return
 
-    gh = releasetool.github.GitHub(
-        releasetool.github.GitHubToken(github_token), use_proxy=use_proxy
-    )
+    gh = releasetool.github.GitHub(github_token, use_proxy=use_proxy)
 
     try:
         owner, repo, number = extract_pr_details(pr)
@@ -117,23 +117,23 @@ def start(github_token: Union[str, dict], pr: str) -> None:
         raise Exception(f"Error commenting on PR: {e.response.status_code}")
 
 
-def finish(github_token: Union[str, dict], pr: str, status: bool, details: str) -> None:
+def finish(github_token_raw: Union[str, dict], pr: str, status: bool, details: str) -> None:
     """Reports the completion of a publication job to GitHub."""
     # If we are passed a dictionary for github_token, assume we are
     # retrieveing a JWT, and do not use magic proxy:
     use_proxy = True
-    if type(github_token) is dict:
+    if type(github_token_raw) is dict:
         use_proxy = False
+        github_token = releasetool.github.GitHubToken.token_from_dict(cast(dict, github_token_raw))
     else:
-        github_token = figure_out_github_token(cast(str, github_token))
+        github_token_raw = figure_out_github_token(cast(str, github_token))
+        releasetool.github.GitHubToken(github_token_raw, 'Bearer')
 
     if not github_token or not pr:
         print("No github token or PR specified to report status to, returning.")
         return
 
-    gh = releasetool.github.GitHub(
-        releasetool.github.GitHubToken(github_token), use_proxy=use_proxy
-    )
+    gh = releasetool.github.GitHub(github_token, use_proxy=use_proxy)
 
     try:
         owner, repo, number = extract_pr_details(pr)

--- a/releasetool/commands/publish_reporter.py
+++ b/releasetool/commands/publish_reporter.py
@@ -80,10 +80,12 @@ def start(github_token_raw: Union[str, dict], pr: str) -> None:
     use_proxy = True
     if type(github_token_raw) is dict:
         use_proxy = False
-        github_token = releasetool.github.GitHubToken.token_from_dict(cast(dict, github_token_raw))
+        github_token = releasetool.github.GitHubToken.token_from_dict(
+            cast(dict, github_token_raw)
+        )
     else:
         github_token_raw = figure_out_github_token(cast(str, github_token))
-        github_token = releasetool.github.GitHubToken(github_token_raw, 'Bearer')
+        github_token = releasetool.github.GitHubToken(github_token_raw, "Bearer")
 
     if not github_token or not pr:
         print("No github token or PR specified to report status to, returning.")
@@ -117,17 +119,21 @@ def start(github_token_raw: Union[str, dict], pr: str) -> None:
         raise Exception(f"Error commenting on PR: {e.response.status_code}")
 
 
-def finish(github_token_raw: Union[str, dict], pr: str, status: bool, details: str) -> None:
+def finish(
+    github_token_raw: Union[str, dict], pr: str, status: bool, details: str
+) -> None:
     """Reports the completion of a publication job to GitHub."""
     # If we are passed a dictionary for github_token, assume we are
     # retrieveing a JWT, and do not use magic proxy:
     use_proxy = True
     if type(github_token_raw) is dict:
         use_proxy = False
-        github_token = releasetool.github.GitHubToken.token_from_dict(cast(dict, github_token_raw))
+        github_token = releasetool.github.GitHubToken.token_from_dict(
+            cast(dict, github_token_raw)
+        )
     else:
         github_token_raw = figure_out_github_token(cast(str, github_token))
-        releasetool.github.GitHubToken(github_token_raw, 'Bearer')
+        releasetool.github.GitHubToken(github_token_raw, "Bearer")
 
     if not github_token or not pr:
         print("No github token or PR specified to report status to, returning.")

--- a/releasetool/commands/publish_reporter.py
+++ b/releasetool/commands/publish_reporter.py
@@ -87,7 +87,7 @@ def start(github_token: Union[str, dict], pr: str) -> None:
         print("No github token or PR specified to report status to, returning.")
         return
 
-    gh = releasetool.github.GitHub(github_token, use_proxy=use_proxy)
+    gh = releasetool.github.GitHub(releasetool.github.GitHubToken(github_token), use_proxy=use_proxy)
 
     try:
         owner, repo, number = extract_pr_details(pr)
@@ -129,7 +129,7 @@ def finish(github_token: Union[str, dict], pr: str, status: bool, details: str) 
         print("No github token or PR specified to report status to, returning.")
         return
 
-    gh = releasetool.github.GitHub(github_token, use_proxy=use_proxy)
+    gh = releasetool.github.GitHub(releasetool.github.GitHubToken(github_token), use_proxy=use_proxy)
 
     try:
         owner, repo, number = extract_pr_details(pr)

--- a/releasetool/commands/publish_reporter.py
+++ b/releasetool/commands/publish_reporter.py
@@ -17,7 +17,7 @@
 import os
 import pkgutil
 import re
-from typing import Tuple
+from typing import cast, Any, Tuple
 from requests import HTTPError
 
 import releasetool.github
@@ -73,15 +73,21 @@ def extract_pr_details(pr) -> Tuple[str, str, str]:
     return match.group("owner"), match.group("repo"), match.group("number")
 
 
-def start(github_token: str, pr: str) -> None:
+def start(github_token: Any, pr: str) -> None:
     """Reports the start of a publication job to GitHub."""
-    github_token = figure_out_github_token(github_token)
+    # If we are passed a dictionary for github_token, assume we are
+    # retrieveing a JWT, and do not use magic proxy:
+    use_proxy = True
+    if type(github_token) is dict:
+        use_proxy = False
+    else:
+        github_token = figure_out_github_token(cast(str, github_token))
 
     if not github_token or not pr:
         print("No github token or PR specified to report status to, returning.")
         return
 
-    gh = releasetool.github.GitHub(github_token, use_proxy=True)
+    gh = releasetool.github.GitHub(github_token, use_proxy=use_proxy)
 
     try:
         owner, repo, number = extract_pr_details(pr)
@@ -109,15 +115,21 @@ def start(github_token: str, pr: str) -> None:
         raise Exception(f"Error commenting on PR: {e.response.status_code}")
 
 
-def finish(github_token: str, pr: str, status: bool, details: str) -> None:
+def finish(github_token: Any, pr: str, status: bool, details: str) -> None:
     """Reports the completion of a publication job to GitHub."""
-    github_token = figure_out_github_token(github_token)
+    # If we are passed a dictionary for github_token, assume we are
+    # retrieveing a JWT, and do not use magic proxy:
+    use_proxy = True
+    if type(github_token) is dict:
+        use_proxy = False
+    else:
+        github_token = figure_out_github_token(cast(str, github_token))
 
     if not github_token or not pr:
         print("No github token or PR specified to report status to, returning.")
         return
 
-    gh = releasetool.github.GitHub(github_token, use_proxy=True)
+    gh = releasetool.github.GitHub(github_token, use_proxy=use_proxy)
 
     try:
         owner, repo, number = extract_pr_details(pr)

--- a/releasetool/commands/publish_reporter.py
+++ b/releasetool/commands/publish_reporter.py
@@ -87,7 +87,9 @@ def start(github_token: Union[str, dict], pr: str) -> None:
         print("No github token or PR specified to report status to, returning.")
         return
 
-    gh = releasetool.github.GitHub(releasetool.github.GitHubToken(github_token), use_proxy=use_proxy)
+    gh = releasetool.github.GitHub(
+        releasetool.github.GitHubToken(github_token), use_proxy=use_proxy
+    )
 
     try:
         owner, repo, number = extract_pr_details(pr)
@@ -129,7 +131,9 @@ def finish(github_token: Union[str, dict], pr: str, status: bool, details: str) 
         print("No github token or PR specified to report status to, returning.")
         return
 
-    gh = releasetool.github.GitHub(releasetool.github.GitHubToken(github_token), use_proxy=use_proxy)
+    gh = releasetool.github.GitHub(
+        releasetool.github.GitHubToken(github_token), use_proxy=use_proxy
+    )
 
     try:
         owner, repo, number = extract_pr_details(pr)

--- a/releasetool/commands/publish_reporter.py
+++ b/releasetool/commands/publish_reporter.py
@@ -17,7 +17,7 @@
 import os
 import pkgutil
 import re
-from typing import cast, Any, Tuple
+from typing import cast, Tuple, Union
 from requests import HTTPError
 
 import releasetool.github
@@ -73,7 +73,7 @@ def extract_pr_details(pr) -> Tuple[str, str, str]:
     return match.group("owner"), match.group("repo"), match.group("number")
 
 
-def start(github_token: Any, pr: str) -> None:
+def start(github_token: Union[str, dict], pr: str) -> None:
     """Reports the start of a publication job to GitHub."""
     # If we are passed a dictionary for github_token, assume we are
     # retrieveing a JWT, and do not use magic proxy:
@@ -115,7 +115,7 @@ def start(github_token: Any, pr: str) -> None:
         raise Exception(f"Error commenting on PR: {e.response.status_code}")
 
 
-def finish(github_token: Any, pr: str, status: bool, details: str) -> None:
+def finish(github_token: Union[str, dict], pr: str, status: bool, details: str) -> None:
     """Reports the completion of a publication job to GitHub."""
     # If we are passed a dictionary for github_token, assume we are
     # retrieveing a JWT, and do not use magic proxy:

--- a/releasetool/commands/publish_reporter.sh
+++ b/releasetool/commands/publish_reporter.sh
@@ -14,10 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if [ -f "$KOKORO_GFILE_DIR/secret_manager/releasetool-publish-reporter-app" ]; then
-    export APP_ID_PATH="$KOKORO_GFILE_DIR/secret_manager/releasetool-publish-reporter-app"
-    export INSTALLATION_ID_PATH="$KOKORO_GFILE_DIR/secret_manager/releasetool-publish-reporter-googleapis-installation"
-    export GITHUB_PRIVATE_KEY_PATH="$KOKORO_GFILE_DIR/secret_manager/releasetool-publish-reporter-pem"
+if [ -f "${KOKORO_GFILE_DIR}/secret_manager/releasetool-publish-reporter-app" ]; then
+    export APP_ID_PATH="${KOKORO_GFILE_DIR}/secret_manager/releasetool-publish-reporter-app"
+    export INSTALLATION_ID_PATH="${KOKORO_GFILE_DIR}/secret_manager/releasetool-publish-reporter-googleapis-installation"
+    export GITHUB_PRIVATE_KEY_PATH="${KOKORO_GFILE_DIR}/secret_manager/releasetool-publish-reporter-pem"
 else
     echo 'could not load GitHub installation credentials'
 fi

--- a/releasetool/commands/publish_reporter.sh
+++ b/releasetool/commands/publish_reporter.sh
@@ -14,9 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export APP_ID_PATH="$KOKORO_GFILE_DIR/secret_manager/releasetool-publish-reporter-app"
-export INSTALLATION_ID_PATH="$KOKORO_GFILE_DIR/secret_manager/releasetool-publish-reporter-googleapis-installation"
-export GITHUB_PRIVATE_KEY_PATH="$KOKORO_GFILE_DIR/secret_manager/releasetool-publish-reporter-pem"
+if [ -f "$KOKORO_GFILE_DIR/secret_manager/releasetool-publish-reporter-app" ]; then
+    export APP_ID_PATH="$KOKORO_GFILE_DIR/secret_manager/releasetool-publish-reporter-app"
+    export INSTALLATION_ID_PATH="$KOKORO_GFILE_DIR/secret_manager/releasetool-publish-reporter-googleapis-installation"
+    export GITHUB_PRIVATE_KEY_PATH="$KOKORO_GFILE_DIR/secret_manager/releasetool-publish-reporter-pem"
+else
+    echo 'could not load GitHub installation credentials'
+fi
 
 # Install an exit hook to report status.
 releasetool_finish_report() {

--- a/releasetool/commands/publish_reporter.sh
+++ b/releasetool/commands/publish_reporter.sh
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+export APP_ID_PATH="$KOKORO_GFILE_DIR/secret_manager/releasetool-publish-reporter-app"
+export INSTALLATION_ID_PATH="$KOKORO_GFILE_DIR/secret_manager/releasetool-publish-reporter-googleapis-installation"
+export GITHUB_PRIVATE_KEY_PATH="$KOKORO_GFILE_DIR/secret_manager/releasetool-publish-reporter-pem"
+
 # Install an exit hook to report status.
 releasetool_finish_report() {
     rv=$?

--- a/releasetool/github.py
+++ b/releasetool/github.py
@@ -72,7 +72,7 @@ class GitHubToken:
             token_dict = cast(dict, token)
             self.token = self.application_access_token(
                 token_dict["app_id"],
-                token_dict["installation"],
+                token_dict["installation_id"],
                 token_dict["private_key"],
             )
 
@@ -83,7 +83,7 @@ class GitHubToken:
         return self.token
 
     def application_access_token(
-        self, app_id: str, installation: str, private_key_str: str
+        self, app_id: str, installation_id: str, private_key_str: str
     ) -> str:
         time_since_epoch_in_seconds = int(time.time())
         # see: https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app
@@ -104,7 +104,7 @@ class GitHubToken:
 
         resp = requests.post(
             "https://api.github.com/installations/{}/access_tokens".format(
-                installation
+                installation_id
             ),
             headers=headers,
         )

--- a/releasetool/github.py
+++ b/releasetool/github.py
@@ -103,7 +103,7 @@ class GitHubToken:
         }
 
         resp = requests.post(
-            "https://api.github.com/installations/{}/access_tokens".format(
+            "https://api.github.com/app/installations/{}/access_tokens".format(
                 installation_id
             ),
             headers=headers,

--- a/releasetool/github.py
+++ b/releasetool/github.py
@@ -18,7 +18,7 @@ import os
 import re
 import time
 
-from typing import cast, Any, List, Sequence, Union
+from typing import cast, List, Sequence, Union
 
 import jwt
 import requests
@@ -62,7 +62,7 @@ def _find_devrel_api_key() -> str:
 
 
 class GitHub:
-    def __init__(self, token: Any, use_proxy: bool = False) -> None:
+    def __init__(self, token: Union[str, dict], use_proxy: bool = False) -> None:
         auth_type = "Bearer"
         token_str = cast(str, token)
         # If a dictionary is provided for token, assume it

--- a/releasetool/github.py
+++ b/releasetool/github.py
@@ -85,7 +85,7 @@ class GitHubToken:
             token["installation_id"],
             token["private_key"],
         )
-        return GitHubToken(access_token, 'token')
+        return GitHubToken(access_token, "token")
 
 
 def get_installation_access_token(

--- a/releasetool/github.py
+++ b/releasetool/github.py
@@ -27,7 +27,9 @@ from cryptography.hazmat.backends import default_backend
 
 _GITHUB_ROOT: str = "https://api.github.com"
 _GITHUB_UI_ROOT: str = "https://github.com"
-_MAGIC_GITHUB_PROXY_ROOT: str = "https://magic-github-proxy.endpoints.devrel-prod.cloud.goog"
+_MAGIC_GITHUB_PROXY_ROOT: str = (
+    "https://magic-github-proxy.endpoints.devrel-prod.cloud.goog"
+)
 
 
 def _find_devrel_api_key() -> str:
@@ -61,18 +63,18 @@ def _find_devrel_api_key() -> str:
 
 class GitHub:
     def __init__(self, token: Any, use_proxy: bool = False) -> None:
-        auth_type = 'Bearer'
+        auth_type = "Bearer"
         token_str = cast(str, token)
         # If a dictionary is provided for token, assume it
         # contains app_id, installation, private_key, such that we
         # can fetch a JWT:
         if type(token) is dict:
-            auth_type = 'token'
+            auth_type = "token"
             token_dict = cast(dict, token)
             token_str = self.application_access_token(
-                token_dict['app_id'],
-                token_dict['installation'],
-                token_dict['private_key']
+                token_dict["app_id"],
+                token_dict["installation"],
+                token_dict["private_key"],
             )
 
         self.session: requests.Session = requests.Session()
@@ -89,32 +91,36 @@ class GitHub:
             # To use the proxy, we need an api key for the magic github proxy.
             self.session.params = {"key": _find_devrel_api_key()}
 
-    def application_access_token(self, app_id: str, installation: str, private_key_str: str) -> str:
+    def application_access_token(
+        self, app_id: str, installation: str, private_key_str: str
+    ) -> str:
         time_since_epoch_in_seconds = int(time.time())
         # see: https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app
         payload = {
-            'iat': time_since_epoch_in_seconds,
-            'exp': time_since_epoch_in_seconds + (10 * 60),
-            'iss': app_id
+            "iat": time_since_epoch_in_seconds,
+            "exp": time_since_epoch_in_seconds + (10 * 60),
+            "iss": app_id,
         }
 
         private_key_bytes = private_key_str.encode()
         private_key = default_backend().load_pem_private_key(private_key_bytes, None)
-        app_jwt = jwt.encode(payload, private_key, algorithm='RS256')
+        app_jwt = jwt.encode(payload, private_key, algorithm="RS256")
 
         headers = {
-            "Authorization":
-            "Bearer {}".format(app_jwt.decode()),
-            "Accept": "application/vnd.github.machine-man-preview+json"
+            "Authorization": "Bearer {}".format(app_jwt.decode()),
+            "Accept": "application/vnd.github.machine-man-preview+json",
         }
 
         resp = requests.post(
-            'https://api.github.com/installations/{}/access_tokens'.format(installation),
-            headers=headers)
+            "https://api.github.com/installations/{}/access_tokens".format(
+                installation
+            ),
+            headers=headers,
+        )
 
         if resp.status_code != 201:
             raise Exception("Could exchange certificate for JWT.")
-        return json.loads(resp.content.decode())['token']
+        return json.loads(resp.content.decode())["token"]
 
     def list_pull_requests(
         self, repository: str, state: str = None, merged: bool = True

--- a/releasetool/github.py
+++ b/releasetool/github.py
@@ -27,6 +27,12 @@ from cryptography.hazmat.backends import default_backend
 
 _GITHUB_ROOT: str = "https://api.github.com"
 _GITHUB_UI_ROOT: str = "https://github.com"
+# TODO: remove references to magic proxy, once we have confirmed the JWT-based
+# approach is working well.
+#
+# magic-proxy provided similar functionality to installation-scoped access
+# tokens, by allowing a token to be generated scoped to a single repository,
+# with limited credentials.
 _MAGIC_GITHUB_PROXY_ROOT: str = (
     "https://magic-github-proxy.endpoints.devrel-prod.cloud.goog"
 )

--- a/releasetool/github.py
+++ b/releasetool/github.py
@@ -63,7 +63,7 @@ def _find_devrel_api_key() -> str:
 
 class GitHubToken:
     def __init__(self, token: Union[str, dict]):
-        self.auth_type = 'Bearer'
+        self.auth_type = "Bearer"
         # If a dictionary is provided for token, assume it
         # contains app_id, installation, private_key, such that we
         # can fetch a JWT:

--- a/releasetool/github.py
+++ b/releasetool/github.py
@@ -18,7 +18,7 @@ import os
 import re
 import time
 
-from typing import cast, List, Sequence, Union
+from typing import List, Sequence, Union
 
 import jwt
 import requests
@@ -68,25 +68,24 @@ def _find_devrel_api_key() -> str:
 
 
 class GitHubToken:
-    def __init__(self, token: Union[str, dict]):
-        self.auth_type = "Bearer"
-        # If a dictionary is provided for token, assume it
-        # contains app_id, installation, private_key, such that we
-        # can fetch a JWT:
-        if type(token) is dict:
-            self.auth_type = "token"
-            token_dict = cast(dict, token)
-            self.token = get_installation_access_token(
-                token_dict["app_id"],
-                token_dict["installation_id"],
-                token_dict["private_key"],
-            )
+    def __init__(self, token: str, auth_type: str):
+        self.auth_type = auth_type
+        self.token = token
 
     def get_auth_type(self) -> str:
         return self.auth_type
 
     def get_token(self) -> str:
         return self.token
+
+    @staticmethod
+    def token_from_dict(token: dict):
+        access_token = get_installation_access_token(
+            token["app_id"],
+            token["installation_id"],
+            token["private_key"],
+        )
+        return GitHubToken(access_token, 'token')
 
 
 def get_installation_access_token(

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,10 @@ dependencies = [
     "requests",
     "attrs",
     "click",
+    "cryptography",
     "keyring",
     "packaging",
+    "pyjwt",
     "pyperclip",
     "python-dateutil",
 ]


### PR DESCRIPTION
This PR assumes that we will set three secrets:

* `APP_ID`: path to a file that contains a GitHub application ID.
* `INSTALLATION`: path to a file that contains an installation ID.
*  `GITHUB_PRIVATE_KEY`:  path to a file that contains the PEM secret for a GitHub application.

If these environments are found set, then rather than using magic-proxy, it grabs a JWT for our application and uses it to authenticate.

_Note: I'm not sure of a great way to write tests for this, but I've done an end to end testing, and confirmed the approach works._

