### PR TITLE
fix: disable PR comments from publish reporter

### DIFF
--- a/releasetool/commands/publish_reporter.py
+++ b/releasetool/commands/publish_reporter.py
@@ -135,18 +135,20 @@ def finish(github_token: str, pr: str, status: bool, details: str) -> None:
     if details:
         message += f"\n{details}"
 
-    try:
-        gh.create_pull_request_comment(f"{owner}/{repo}", number, message)
-    except HTTPError as e:
-        # wrap exception so we don't show the proxy url
-        raise Exception(f"Error commenting on PR: {e.response.status_code}")
+# TODO(busunkim): re-enable commenting once auth issues are resolved
+# https://github.com/googleapis/releasetool/pulls
+#     try:
+#         gh.create_pull_request_comment(f"{owner}/{repo}", number, message)
+#     except HTTPError as e:
+#         # wrap exception so we don't show the proxy url
+#         raise Exception(f"Error commenting on PR: {e.response.status_code}")
 
-    try:
-        pull = gh.get_pull_request(f"{owner}/{repo}", number)
-        gh.update_pull_labels(pull, add=labels, remove=["autorelease: tagged"])
-    except HTTPError as e:
-        # wrap exception so we don't show the proxy url
-        raise Exception(f"Error updating lables on PR: {e.response.status_code}")
+#     try:
+#         pull = gh.get_pull_request(f"{owner}/{repo}", number)
+#         gh.update_pull_labels(pull, add=labels, remove=["autorelease: tagged"])
+#     except HTTPError as e:
+#         # wrap exception so we don't show the proxy url
+#         raise Exception(f"Error updating lables on PR: {e.response.status_code}")
 
 
 def script():

--- a/releasetool/commands/publish_reporter.py
+++ b/releasetool/commands/publish_reporter.py
@@ -135,6 +135,7 @@ def finish(github_token: str, pr: str, status: bool, details: str) -> None:
     if details:
         message += f"\n{details}"
 
+
 # TODO(busunkim): re-enable commenting once auth issues are resolved
 # https://github.com/googleapis/releasetool/pulls
 #     try:

--- a/releasetool/github.py
+++ b/releasetool/github.py
@@ -22,7 +22,9 @@ import requests
 
 _GITHUB_ROOT: str = "https://api.github.com"
 _GITHUB_UI_ROOT: str = "https://github.com"
-_MAGIC_GITHUB_PROXY_ROOT: str = "https://magic-github-proxy.endpoints.devrel-prod.cloud.goog"
+_MAGIC_GITHUB_PROXY_ROOT: str = (
+    "https://magic-github-proxy.endpoints.devrel-prod.cloud.goog"
+)
 
 
 def _find_devrel_api_key() -> str:


### PR DESCRIPTION
The exception still seems to be showing the full URL and causing release jobs to stop.