### PR TITLE
fix(nodejs): move back to autorelease for publishes

### DIFF
--- a/releasetool/commands/tag/nodejs.py
+++ b/releasetool/commands/tag/nodejs.py
@@ -24,12 +24,6 @@ import releasetool.secrets
 import releasetool.commands.common
 from releasetool.commands.common import TagContext
 
-# repos that still use kokoro for publication:
-nodejs_handle_publish = [
-    "googleapis/google-api-nodejs-client",
-    "googleapis/nodejs-logging",
-]
-
 
 def determine_release_pr(ctx: TagContext) -> None:
     click.secho(
@@ -76,14 +70,9 @@ def determine_package_version(ctx: TagContext) -> None:
 
 
 def determine_kokoro_job_name(ctx: TagContext) -> None:
-    if ctx.upstream_repo in nodejs_handle_publish:
-        ctx.kokoro_job_name = (
-            f"cloud-devrel/client-libraries/nodejs/release/{ctx.upstream_repo}/publish"
-        )
-    else:
-        ctx.kokoro_job_name = (
-            f"cloud-devrel/client-libraries/nodejs/release/{ctx.upstream_repo}/docs"
-        )
+    ctx.kokoro_job_name = (
+        f"cloud-devrel/client-libraries/nodejs/release/{ctx.upstream_repo}/publish"
+    )
 
 
 def get_release_notes(ctx: TagContext) -> None:


### PR DESCRIPTION
We continue to have bad luck with the GCF function Node.js was using for publication, for instance it likes to run out of memory for some publications.

Let's move back to kokoro, and call this  a failed experiment.