### PR TITLE
fix: referenced github_token rather than github_token_raw

### DIFF
--- a/releasetool/commands/publish_reporter.py
+++ b/releasetool/commands/publish_reporter.py
@@ -84,7 +84,7 @@ def start(github_token_raw: Union[str, dict], pr: str) -> None:
             cast(dict, github_token_raw)
         )
     else:
-        github_token_raw = figure_out_github_token(cast(str, github_token))
+        github_token_raw = figure_out_github_token(cast(str, github_token_raw))
         github_token = releasetool.github.GitHubToken(github_token_raw, "Bearer")
 
     if not github_token or not pr:
@@ -132,8 +132,8 @@ def finish(
             cast(dict, github_token_raw)
         )
     else:
-        github_token_raw = figure_out_github_token(cast(str, github_token))
-        releasetool.github.GitHubToken(github_token_raw, "Bearer")
+        github_token_raw = figure_out_github_token(cast(str, github_token_raw))
+        github_token = releasetool.github.GitHubToken(github_token_raw, "Bearer")
 
     if not github_token or not pr:
         print("No github token or PR specified to report status to, returning.")

--- a/tests/test_publish_reporter.py
+++ b/tests/test_publish_reporter.py
@@ -35,3 +35,6 @@ class PublishReporter(unittest.TestCase):
                     "abc123", "http://example.com", True, ""
                 )
             assert "magic github proxy api key is required" in str(err.value)
+
+    # TODO: use requests_mock to flesh out more thorough tests
+    # see: https://github.com/googleapis/synthtool/blob/8cf6d2834ad14318e64429c3b94f6443ae83daf9/tests/test_language_java.py#L69-L76

--- a/tests/test_publish_reporter.py
+++ b/tests/test_publish_reporter.py
@@ -1,0 +1,36 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import pytest
+import unittest
+import releasetool.commands.publish_reporter
+
+
+class PublishReporter(unittest.TestCase):
+    def test_publish_reporter_start_devrel_api_key(self):
+        original = os.environ.get("KOKORO_KEYSTORE_DIR", "")
+        os.environ["KOKORO_KEYSTORE_DIR"] = './'
+        with pytest.raises(Exception) as err:
+            releasetool.commands.publish_reporter.start('abc123', 'http://example.com')
+        os.environ["KOKORO_KEYSTORE_DIR"] = original
+        assert "magic github proxy api key is required" in str(err.value)
+
+    def test_publish_reporter_finish_devrel_api_key(self):
+        original = os.environ.get("KOKORO_KEYSTORE_DIR", "")
+        os.environ["KOKORO_KEYSTORE_DIR"] = './'
+        with pytest.raises(Exception) as err:
+            releasetool.commands.publish_reporter.finish('abc123', 'http://example.com', True, '')
+        os.environ["KOKORO_KEYSTORE_DIR"] = original
+        assert "magic github proxy api key is required" in str(err.value)

--- a/tests/test_publish_reporter.py
+++ b/tests/test_publish_reporter.py
@@ -24,7 +24,9 @@ class PublishReporter(unittest.TestCase):
         os.environ["KOKORO_KEYSTORE_DIR"] = "./"
         try:
             with pytest.raises(Exception) as err:
-                releasetool.commands.publish_reporter.start("abc123", "http://example.com")
+                releasetool.commands.publish_reporter.start(
+                    "abc123", "http://example.com"
+                )
             assert "magic github proxy api key is required" in str(err.value)
         finally:
             os.environ["KOKORO_KEYSTORE_DIR"] = original

--- a/tests/test_publish_reporter.py
+++ b/tests/test_publish_reporter.py
@@ -21,16 +21,18 @@ import releasetool.commands.publish_reporter
 class PublishReporter(unittest.TestCase):
     def test_publish_reporter_start_devrel_api_key(self):
         original = os.environ.get("KOKORO_KEYSTORE_DIR", "")
-        os.environ["KOKORO_KEYSTORE_DIR"] = './'
+        os.environ["KOKORO_KEYSTORE_DIR"] = "./"
         with pytest.raises(Exception) as err:
-            releasetool.commands.publish_reporter.start('abc123', 'http://example.com')
+            releasetool.commands.publish_reporter.start("abc123", "http://example.com")
         os.environ["KOKORO_KEYSTORE_DIR"] = original
         assert "magic github proxy api key is required" in str(err.value)
 
     def test_publish_reporter_finish_devrel_api_key(self):
         original = os.environ.get("KOKORO_KEYSTORE_DIR", "")
-        os.environ["KOKORO_KEYSTORE_DIR"] = './'
+        os.environ["KOKORO_KEYSTORE_DIR"] = "./"
         with pytest.raises(Exception) as err:
-            releasetool.commands.publish_reporter.finish('abc123', 'http://example.com', True, '')
+            releasetool.commands.publish_reporter.finish(
+                "abc123", "http://example.com", True, ""
+            )
         os.environ["KOKORO_KEYSTORE_DIR"] = original
         assert "magic github proxy api key is required" in str(err.value)

--- a/tests/test_publish_reporter.py
+++ b/tests/test_publish_reporter.py
@@ -15,30 +15,23 @@
 import os
 import pytest
 import unittest
+from unittest.mock import patch
 import releasetool.commands.publish_reporter
 
 
 class PublishReporter(unittest.TestCase):
     def test_publish_reporter_start_devrel_api_key(self):
-        original = os.environ.get("KOKORO_KEYSTORE_DIR", "")
-        os.environ["KOKORO_KEYSTORE_DIR"] = "./"
-        try:
+        with patch.dict(os.environ, {"KOKORO_KEYSTORE_DIR": "./"}):
             with pytest.raises(Exception) as err:
                 releasetool.commands.publish_reporter.start(
                     "abc123", "http://example.com"
                 )
             assert "magic github proxy api key is required" in str(err.value)
-        finally:
-            os.environ["KOKORO_KEYSTORE_DIR"] = original
 
     def test_publish_reporter_finish_devrel_api_key(self):
-        original = os.environ.get("KOKORO_KEYSTORE_DIR", "")
-        os.environ["KOKORO_KEYSTORE_DIR"] = "./"
-        try:
+        with patch.dict(os.environ, {"KOKORO_KEYSTORE_DIR": "./"}):
             with pytest.raises(Exception) as err:
                 releasetool.commands.publish_reporter.finish(
                     "abc123", "http://example.com", True, ""
                 )
             assert "magic github proxy api key is required" in str(err.value)
-        finally:
-            os.environ["KOKORO_KEYSTORE_DIR"] = original

--- a/tests/test_publish_reporter.py
+++ b/tests/test_publish_reporter.py
@@ -22,17 +22,21 @@ class PublishReporter(unittest.TestCase):
     def test_publish_reporter_start_devrel_api_key(self):
         original = os.environ.get("KOKORO_KEYSTORE_DIR", "")
         os.environ["KOKORO_KEYSTORE_DIR"] = "./"
-        with pytest.raises(Exception) as err:
-            releasetool.commands.publish_reporter.start("abc123", "http://example.com")
-        os.environ["KOKORO_KEYSTORE_DIR"] = original
-        assert "magic github proxy api key is required" in str(err.value)
+        try:
+            with pytest.raises(Exception) as err:
+                releasetool.commands.publish_reporter.start("abc123", "http://example.com")
+            assert "magic github proxy api key is required" in str(err.value)
+        finally:
+            os.environ["KOKORO_KEYSTORE_DIR"] = original
 
     def test_publish_reporter_finish_devrel_api_key(self):
         original = os.environ.get("KOKORO_KEYSTORE_DIR", "")
         os.environ["KOKORO_KEYSTORE_DIR"] = "./"
-        with pytest.raises(Exception) as err:
-            releasetool.commands.publish_reporter.finish(
-                "abc123", "http://example.com", True, ""
-            )
-        os.environ["KOKORO_KEYSTORE_DIR"] = original
-        assert "magic github proxy api key is required" in str(err.value)
+        try:
+            with pytest.raises(Exception) as err:
+                releasetool.commands.publish_reporter.finish(
+                    "abc123", "http://example.com", True, ""
+                )
+            assert "magic github proxy api key is required" in str(err.value)
+        finally:
+            os.environ["KOKORO_KEYSTORE_DIR"] = original


### PR DESCRIPTION
During refactor accidentally left reference to GitHub token, rather than github_token_raw.