### PR TITLE
feat: Allow the .NET autorelease process to work across multiple repositories

### DIFF
--- a/releasetool/commands/tag/dotnet.py
+++ b/releasetool/commands/tag/dotnet.py
@@ -82,7 +82,9 @@ def create_releases(ctx: TagContext) -> None:
     # This isn't a tag, but that's okay - it just needs to be a commitish for
     # Kokoro to build against.
     ctx.release_tag = commitish
-    ctx.kokoro_job_name = "cloud-sharp/google-cloud-dotnet/gcp_windows/autorelease"
+
+    repo_short_name = ctx.upstream_repo.split("/")[-1]
+    ctx.kokoro_job_name = f"cloud-sharp/{repo_short_name}/gcp_windows/autorelease"
     ctx.github.update_pull_labels(
         ctx.release_pr, add=["autorelease: tagged"], remove=["autorelease: pending"]
     )


### PR DESCRIPTION
We assume only the repo name matters, not the organization: the
kokoro job path does not contain the organization.