### PR TITLE
build: updates to config

### DIFF
--- a/.kokoro/release/release.cfg
+++ b/.kokoro/release/release.cfg
@@ -1,30 +1,10 @@
 # Format: //devtools/kokoro/config/proto/build.proto
-# Download secrets from Cloud Storage.
-gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/yoshi-tools"
 
-# The github token is stored here.
-before_action {
-  fetch_keystore {
-    keystore_resource {
-      keystore_config_id: 73713
-      keyname: "releasetool-magictoken"
-      # TODO(busunkim): remove this after secrets have globally propagated
-      backend_type: FASTCONFIGPUSH
-    }
-  }
-}
+# Download trampoline resources.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
 
-# The github token is stored here.
-before_action {
-  fetch_keystore {
-    keystore_resource {
-      keystore_config_id: 73713
-      keyname: "magic-github-proxy-api-key"
-      # TODO(busunkim): remove this after secrets have globally propagated
-      backend_type: FASTCONFIGPUSH
-    }
-  }
-}
+# Use the trampoline script to run in docker.
+build_file: "releasetool/.kokoro/trampoline.sh"
 
 env_vars: {
   key: "SECRET_MANAGER_KEYS"
@@ -34,4 +14,10 @@ env_vars: {
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
     value: "github/releasetool/.kokoro/release.sh"
+}
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/python"
 }


### PR DESCRIPTION
@busunkim96 I'm seeing the error in logs:

```bash
[18:08:00][ERROR] Failed to get build config
com.google.devtools.kokoro.config.ConfigException: Neither the Build file nor the Cloud build local config have been specified
	at com.google.devtools.kokoro.config.factory.BuilderPluginFactory.createBatchBuilder(BuilderPluginFactory.java:143)
	at com.google.devtools.kokoro.config.factory.BuilderPluginFactory.from(BuilderPluginFactory.java:72)
	at com.google.devtools.kokoro.jenkins.plugin.kokorojob.KokoroBuildConfig$Builder.buildWith(KokoroBuildConfig.java:83)
	at com.google.devtools.kokoro.jenkins.plugin.kokorojob.store.ConfigStore.getKokoroBuildConfig(ConfigStore.java:120)
```

I was wondering if it's because we don't read the top level common.cfg, where these files are defined? 


CC: @jskeet. 