### PR TITLE
build: use gcloudpypi account for release

### DIFF
--- a/.kokoro/populate-secrets.sh
+++ b/.kokoro/populate-secrets.sh
@@ -33,8 +33,8 @@ do
     gcr.io/google.com/cloudsdktool/cloud-sdk \
     secrets versions access latest \
     --project cloud-devrel-kokoro-resources \
-    --secret $key > \
-    "$SECRET_LOCATION/$key"
+    --secret ${key} > \
+    "${SECRET_LOCATION}/${key}"
   if [[ $? == 0 ]]; then
     msg "Secret written to ${SECRET_LOCATION}/${key}"
   else

--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 
 # Copyright 2018 Google LLC
@@ -25,7 +24,7 @@ python3 -m releasetool publish-reporter-script > /tmp/publisher-script; source /
 
 # Move into the package, build the distribution and upload.
 cd github/releasetool
-TWINE_PASSWORD=$(cat "${KOKORO_KEYSTORE_DIR}/73713_google_cloud_pypi_password")
+TWINE_PASSWORD=$(cat "${KOKORO_GFILE_DIR}/google-cloud-pypi-password")
 
 # Ensure that we have the latest versions of Twine, Wheel, and Setuptools.
 python3 -m pip install --upgrade twine wheel setuptools
@@ -34,4 +33,4 @@ python3 -m pip install --upgrade twine wheel setuptools
 export PYTHONUNBUFFERED=1
 
 python3 setup.py sdist bdist_wheel
-twine upload --username gcloudpypi --password "${TWINE_PASSWORD}" dist/*
+twine upload --username __token__ --password "${TWINE_PASSWORD}" dist/*

--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -1,4 +1,6 @@
+
 #!/bin/bash
+
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,9 +17,15 @@
 
 set -eo pipefail
 
-# Start the releasetool reporter
-python3 -m pip install gcp-releasetool
+# Enable the publish build reporter
+# Note: this installs from source since we're in the releasetool repo. Other projects
+# will need to use python3 -m pip install gcp-releasetool
+python3 -m pip install github/releasetool
 python3 -m releasetool publish-reporter-script > /tmp/publisher-script; source /tmp/publisher-script
+
+# Move into the package, build the distribution and upload.
+cd github/releasetool
+TWINE_PASSWORD=$(cat "${KOKORO_KEYSTORE_DIR}/73713_google_cloud_pypi_password")
 
 # Ensure that we have the latest versions of Twine, Wheel, and Setuptools.
 python3 -m pip install --upgrade twine wheel setuptools
@@ -25,8 +33,5 @@ python3 -m pip install --upgrade twine wheel setuptools
 # Disable buffering, so that the logs stream through.
 export PYTHONUNBUFFERED=1
 
-# Move into the package, build the distribution and upload.
-TWINE_PASSWORD=$(cat "${KOKORO_KEYSTORE_DIR}/73713_google_cloud_pypi_password")
-cd github/python-automl
 python3 setup.py sdist bdist_wheel
 twine upload --username gcloudpypi --password "${TWINE_PASSWORD}" dist/*

--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -24,7 +24,7 @@ python3 -m releasetool publish-reporter-script > /tmp/publisher-script; source /
 
 # Move into the package, build the distribution and upload.
 cd github/releasetool
-TWINE_PASSWORD=$(cat "${KOKORO_GFILE_DIR}/google-cloud-pypi-password")
+TWINE_PASSWORD=$(cat "${KOKORO_GFILE_DIR}/secret_manager/google-cloud-pypi-password")
 
 # Ensure that we have the latest versions of Twine, Wheel, and Setuptools.
 python3 -m pip install --upgrade twine wheel setuptools

--- a/.kokoro/release/common.cfg
+++ b/.kokoro/release/common.cfg
@@ -1,2 +1,1 @@
-
 # Format: //devtools/kokoro/config/proto/build.proto

--- a/.kokoro/release/release.cfg
+++ b/.kokoro/release/release.cfg
@@ -19,5 +19,5 @@ env_vars: {
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/python-multi"
+    value: "gcr.io/cloud-devrel-kokoro-resources/python"
 }

--- a/.kokoro/release/release.cfg
+++ b/.kokoro/release/release.cfg
@@ -8,7 +8,7 @@ build_file: "releasetool/.kokoro/trampoline.sh"
 
 env_vars: {
   key: "SECRET_MANAGER_KEYS"
-  value: "releasetool-publish-reporter-app,releasetool-publish-reporter-googleapis-installation,releasetool-publish-reporter-pem"
+  value: "releasetool-publish-reporter-app,releasetool-publish-reporter-googleapis-installation,releasetool-publish-reporter-pem,google-cloud-pypi-password"
 }
 
 env_vars: {
@@ -19,5 +19,5 @@ env_vars: {
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/python"
+    value: "gcr.io/cloud-devrel-kokoro-resources/python-multi"
 }


### PR DESCRIPTION
I've confirmed that the release build succeeds by building off my branch.

This switches releasetool publishing to the PyPI account `gcloudpypi`. I added the secret to secret manager.