### PR TITLE
fix(nodejs): semver digits are not optional

### DIFF
--- a/releasetool/commands/tag/nodejs.py
+++ b/releasetool/commands/tag/nodejs.py
@@ -64,7 +64,7 @@ def determine_release_tag(ctx: TagContext) -> None:
 
 def determine_package_version(ctx: TagContext) -> None:
     click.secho("> Determining the package version.", fg="cyan")
-    match = re.match(r"(?P<version>v?\d+?\.\d+?\.\d+?)", ctx.release_tag)
+    match = re.match(r"(?P<version>v?\d+\.\d+\.\d+)", ctx.release_tag)
     ctx.release_version = match.group("version")
     click.secho(f"package version: {ctx.release_version}.")
 


### PR DESCRIPTION
I think this regex can just drop the `?`.