### PR TITLE
feat(ruby): Support releases of split ruby apiary packages

### DIFF
--- a/releasetool/commands/tag/ruby.py
+++ b/releasetool/commands/tag/ruby.py
@@ -79,7 +79,10 @@ def determine_package_name_and_version(ctx: TagContext) -> None:
 
 def get_release_notes(ctx: TagContext) -> None:
     click.secho("> Grabbing the release notes.", fg="cyan")
-    if "google-cloud-ruby" in ctx.upstream_repo or "google-api-ruby-client" in ctx.upstream_repo:
+    if (
+        "google-cloud-ruby" in ctx.upstream_repo
+        or "google-api-ruby-client" in ctx.upstream_repo
+    ):
         changelog_file = f"{ctx.package_name}/CHANGELOG.md"
     else:
         changelog_file = "CHANGELOG.md"
@@ -157,9 +160,7 @@ def tag(ctx: TagContext = None) -> TagContext:
             f"cloud-devrel/client-libraries/google-cloud-ruby/release/{job_name}"
         )
     elif "google-api-ruby-client" in ctx.upstream_repo:
-        ctx.kokoro_job_name = (
-            f"cloud-devrel/client-libraries/google-api-ruby-client/release/{ctx.package_name}"
-        )
+        ctx.kokoro_job_name = f"cloud-devrel/client-libraries/google-api-ruby-client/release/{ctx.package_name}"
     else:
         ctx.kokoro_job_name = (
             f"cloud-devrel/client-libraries/{ctx.package_name}/release"

--- a/releasetool/commands/tag/ruby.py
+++ b/releasetool/commands/tag/ruby.py
@@ -79,7 +79,7 @@ def determine_package_name_and_version(ctx: TagContext) -> None:
 
 def get_release_notes(ctx: TagContext) -> None:
     click.secho("> Grabbing the release notes.", fg="cyan")
-    if "google-cloud-ruby" in ctx.upstream_repo:
+    if "google-cloud-ruby" in ctx.upstream_repo or "google-api-ruby-client" in ctx.upstream_repo:
         changelog_file = f"{ctx.package_name}/CHANGELOG.md"
     else:
         changelog_file = "CHANGELOG.md"
@@ -151,11 +151,14 @@ def tag(ctx: TagContext = None) -> TagContext:
 
     create_release(ctx)
 
-    job_name = ctx.package_name.split("google-cloud-")[-1]
-
     if "google-cloud-ruby" in ctx.upstream_repo:
+        job_name = ctx.package_name.split("google-cloud-")[-1]
         ctx.kokoro_job_name = (
             f"cloud-devrel/client-libraries/google-cloud-ruby/release/{job_name}"
+        )
+    elif "google-api-ruby-client" in ctx.upstream_repo:
+        ctx.kokoro_job_name = (
+            f"cloud-devrel/client-libraries/google-api-ruby-client/release/{ctx.package_name}"
         )
     else:
         ctx.kokoro_job_name = (


### PR DESCRIPTION
The Ruby apiary library is being broken out into separate libraries per service, along with separate core and generator libraries. As a result, the Ruby Apiary monorepo now contains multiple packages, each in a subdirectory.

This PR updates the Ruby release tagging logic to support this restructuring.

* Update the code that finds changelogs to look in the appropriate subdirectory.
* Update the code that determines which kokoro release job to trigger.

See internal cl/349793870