### PR TITLE
fix: Remove spurious method call when exchanging JWT for an access token

### DIFF
--- a/releasetool/github.py
+++ b/releasetool/github.py
@@ -107,7 +107,7 @@ def get_installation_access_token(
     app_jwt = jwt.encode(payload, private_key, algorithm="RS256")
 
     headers = {
-        "Authorization": "Bearer {}".format(app_jwt.decode()),
+        "Authorization": "Bearer {}".format(app_jwt),
         "Accept": "application/vnd.github.machine-man-preview+json",
     }
 


### PR DESCRIPTION
mypy is flagging a type issue, causing CI to fail in #294 and #295 . I think this should fix the issue. There's a spurious method being called on the encoded JWT (a string). I'm pretty sure the string can be set in the header as-is.

Requesting review from @bcoe because this was your code from #262 and I want to make sure there isn't something I'm missing.