### PR TITLE
build: use trampoline/docker for autorelease job

### DIFF
--- a/.kokoro-autorelease/build.sh
+++ b/.kokoro-autorelease/build.sh
@@ -17,20 +17,17 @@ set -eo pipefail
 
 cd ${KOKORO_ARTIFACTS_DIR}/github/releasetool
 
-# Upgrade the NPM version
-sudo npm install -g npm
-
-# Kokoro currently uses 3.6.1
-pyenv global 3.6.1
+# Docker images currently uses 3.7.4
 
 # Disable buffering, so that the logs stream through.
 export PYTHONUNBUFFERED=1
 
-# Add github to known hosts.
-ssh-keyscan github.com >> ~/.ssh/known_hosts
-
 # The key for triggering Kokoro jobs is a Keystore resource, so it'll be here.
 export AUTORELEASE_KOKORO_CREDENTIALS=${KOKORO_KEYSTORE_DIR}/73713_kokoro_trigger_credentials
+
+# install release-please binary to do tagging
+npm i release-please
+npx release-please --version
 
 python3 -m pip install --quiet --user --upgrade -r requirements.txt
 python3 -m autorelease --report sponge_log.xml ${AUTORELEASE_COMMAND}

--- a/.kokoro-autorelease/common.cfg
+++ b/.kokoro-autorelease/common.cfg
@@ -14,7 +14,22 @@
 
 # Format: //devtools/kokoro/config/proto/build.proto
 
-build_file: "releasetool/.kokoro-autorelease/build.sh"
+# Download trampoline resources.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
+
+build_file: "releasetool/.kokoro/trampoline.sh"
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/node:12-user"
+}
+
+# Tell the trampoline which build file to use.
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/releasetool/.kokoro-autorelease/build.sh"
+}
 
 # Build logs will be here
 action {

--- a/.kokoro-autorelease/common.cfg
+++ b/.kokoro-autorelease/common.cfg
@@ -22,7 +22,7 @@ build_file: "releasetool/.kokoro/trampoline.sh"
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/node:12-user"
+    value: "gcr.io/cloud-devrel-kokoro-resources/node:14-user"
 }
 
 # Tell the trampoline which build file to use.


### PR DESCRIPTION
Currently, we're running the autorelease job directly on the Kokoro VM. Permissions can be wonky and it's hard to control installed versions.

This allows us to control the runtime environment by using Docker images that we maintain.