### PR TITLE
fix(java): use release-please for java tagging

### DIFF
--- a/autorelease/__main__.py
+++ b/autorelease/__main__.py
@@ -25,7 +25,7 @@ _KEYSTORE_GITHUB_TOKEN_LOCATION = "73713_yoshi-automation-github-key"
 def _determine_github_token(github_token):
     """Automatically use the GitHub token provided by Keystore if needed."""
     if github_token is not None:
-        return
+        return github_token
 
     if "KOKORO_KEYSTORE_DIR" in os.environ:
         filename = os.path.join(

--- a/autorelease/tag.py
+++ b/autorelease/tag.py
@@ -31,6 +31,7 @@ def run_releasetool_tag(lang: str, gh: github.GitHub, pull: dict) -> None:
     ctx.interactive = False
     # TODO(busunkim): Use proxy once KMS setup is complete.
     ctx.github = releasetool.github.GitHub(gh.token, use_proxy=False)
+    ctx.token = gh.token
     ctx.upstream_repo = pull["base"]["repo"]["full_name"]
     ctx.release_pr = pull
     return language_module.tag(ctx)

--- a/releasetool/commands/common.py
+++ b/releasetool/commands/common.py
@@ -53,6 +53,7 @@ class TagContext(GitHubContext):
     github_release: Optional[dict] = None
     kokoro_job_name: Optional[str] = None
     fusion_url: Optional[str] = None
+    token: Optional[str] = None
 
 
 def _determine_origin(ctx: GitHubContext) -> None:

--- a/releasetool/commands/tag/java.py
+++ b/releasetool/commands/tag/java.py
@@ -14,6 +14,7 @@
 
 import getpass
 import re
+import subprocess
 
 import click
 
@@ -130,20 +131,22 @@ def tag(ctx: TagContext = None) -> TagContext:
     if ctx.github is None:
         releasetool.commands.common.setup_github_context(ctx)
 
-    if ctx.release_pr is None:
-        determine_release_pr(ctx)
-
-    determine_release_tag(ctx)
-    determine_package_name_and_version(ctx)
-
-    # If the release already exists, don't do anything
-    if releasetool.commands.common.release_exists(ctx):
-        click.secho(f"{ctx.release_tag} already exists.", fg="magenta")
-        return ctx
-
-    get_release_notes(ctx)
-    create_release(ctx)
-
+    # delegate releaase tagging to release-please
+    default_branch = ctx.release_pr["base"]["ref"]
+    repo = ctx.release_pr["base"]["repo"]["full_name"]
+    subprocess.check_call(
+        [
+            "npx",
+            "release-please",
+            "github-release",
+            f"--token={ctx.token}",
+            f"--default-branch={default_branch}",
+            "--release-type=java-yoshi",
+            "--bump-minor-pre-major=true",
+            f"--repo-url={repo}",
+            "--package-name=",
+        ]
+    )
     if ctx.interactive:
         click.secho("\\o/ All done!", fg="magenta")
 


### PR DESCRIPTION
Delegate tagging to release-please for Java. This is needed to unblock Java release tagging which has gotten more complicated to support multiple release branches.

A more robust design to support all languages is forthcoming.