### PR TITLE
fix(java): use token file for release-please

### DIFF
--- a/releasetool/commands/tag/java.py
+++ b/releasetool/commands/tag/java.py
@@ -138,7 +138,7 @@ def tag(ctx: TagContext = None) -> TagContext:
     with tempfile.NamedTemporaryFile("w+") as fp:
         fp.write(ctx.token)
         token_file = fp.name
-        
+
     subprocess.check_call(
         [
             "npx",

--- a/releasetool/commands/tag/java.py
+++ b/releasetool/commands/tag/java.py
@@ -15,7 +15,7 @@
 import getpass
 import re
 import subprocess
-
+import tempfile
 import click
 
 import releasetool.circleci
@@ -134,12 +134,17 @@ def tag(ctx: TagContext = None) -> TagContext:
     # delegate releaase tagging to release-please
     default_branch = ctx.release_pr["base"]["ref"]
     repo = ctx.release_pr["base"]["repo"]["full_name"]
+
+    with tempfile.NamedTemporaryFile("w+") as fp:
+        fp.write(ctx.token)
+        token_file = fp.name
+        
     subprocess.check_call(
         [
             "npx",
             "release-please",
             "github-release",
-            f"--token={ctx.token}",
+            f"--token={token_file}",
             f"--default-branch={default_branch}",
             "--release-type=java-yoshi",
             "--bump-minor-pre-major=true",


### PR DESCRIPTION
If release-please fails, autorelease tries to log the failing command