### PR TITLE
fix: switch to using search API for finding merged release PRs

### DIFF
--- a/autorelease/github.py
+++ b/autorelease/github.py
@@ -93,7 +93,7 @@ class GitHub:
         self, org: str, state: str = None, labels: str = None
     ) -> Generator[dict, None, None]:
         url = (
-            f"{self.GITHUB_ROOT}/search/issues?q=org:{quote(org)}+state:{quote(state)}"
+            f"{self.GITHUB_ROOT}/search/issues?q=org:{quote(org)}+state:{quote(state)}+archived:false"
         )
         if labels:
             # Note: GitHub query API expects label to be enclosed in quotes:

--- a/autorelease/github.py
+++ b/autorelease/github.py
@@ -92,9 +92,7 @@ class GitHub:
     def list_org_issues(
         self, org: str, state: str = None, labels: str = None
     ) -> Generator[dict, None, None]:
-        url = (
-            f"{self.GITHUB_ROOT}/search/issues?q=org:{quote(org)}+state:{quote(state)}+archived:false"
-        )
+        url = f"{self.GITHUB_ROOT}/search/issues?q=org:{quote(org)}+state:{quote(state)}+archived:false"
         if labels:
             # Note: GitHub query API expects label to be enclosed in quotes:
             quotedLabels = '"' + labels + '"'

--- a/autorelease/tag.py
+++ b/autorelease/tag.py
@@ -85,9 +85,6 @@ def main(args) -> reporter.Reporter:
     try:
         issues = gh.list_org_issues(
             org=org,
-            # Get all issues. By default, GitHub only returns issues assigned to
-            # the authenticated user.
-            filter="all",
             # Must be merged ("closed").
             state="closed",
             # Must be labeled with "autorelease: pending"


### PR DESCRIPTION
I've done a healthy amount of QA, and switching to the search endpoint seems promising.

The API is described [here](https://docs.github.com/en/github/searching-for-information-on-github/searching-issues-and-pull-requests).

Queries end up looking something like this:

```curl
curl https://api.github.com/search/issues?q=org:googleapis+state:closed+label:%22autorelease%3A%20pending%22
```

Fixes #307 