### PR TITLE
fix(manifest): defer to manifest releaser for version/CHANGELOG

### DIFF
--- a/releasetool/commands/common.py
+++ b/releasetool/commands/common.py
@@ -184,8 +184,7 @@ def publish_via_kokoro(ctx: TagContext) -> None:
         )
 
     click.secho(f"Kokoro build URL:\t\t{click.style(ctx.fusion_url, underline=True)}")
-    if ctx.release_tag:
-        click.secho(f"Commitish:\t{click.style(ctx.release_tag, bold=True)}")
+    click.secho(f"Commitish:\t{click.style(ctx.release_tag, bold=True)}")
 
     if ctx.interactive:
         if click.confirm("Would you like to go the Kokoro build page?", default=True):

--- a/releasetool/commands/common.py
+++ b/releasetool/commands/common.py
@@ -184,7 +184,8 @@ def publish_via_kokoro(ctx: TagContext) -> None:
         )
 
     click.secho(f"Kokoro build URL:\t\t{click.style(ctx.fusion_url, underline=True)}")
-    click.secho(f"Commitish:\t{click.style(ctx.release_tag, bold=True)}")
+    if ctx.release_tag:
+        click.secho(f"Commitish:\t{click.style(ctx.release_tag, bold=True)}")
 
     if ctx.interactive:
         if click.confirm("Would you like to go the Kokoro build page?", default=True):

--- a/releasetool/commands/tag/nodejs.py
+++ b/releasetool/commands/tag/nodejs.py
@@ -199,7 +199,7 @@ def tag(ctx: TagContext = None) -> TagContext:
         # branch as the staging area for a publish.
         # TODO(bcoe/chingor13): what are the ramifications of this,
         # if a publish is delayed significantly.
-        ctx.release_tag = 'main'
+        ctx.release_tag = "main"
 
     create_release(ctx)
     determine_kokoro_job_name(ctx)

--- a/releasetool/commands/tag/nodejs.py
+++ b/releasetool/commands/tag/nodejs.py
@@ -194,6 +194,12 @@ def tag(ctx: TagContext = None) -> TagContext:
             click.secho(f"{ctx.release_tag} already exists.", fg="magenta")
             return ctx
         get_release_notes(ctx)
+    else:
+        # If using mono-release strategy, fallback to using the primary
+        # branch as the staging area for a publish.
+        # TODO(bcoe/chingor13): what are the ramifications of this,
+        # if a publish is delayed significantly.
+        ctx.release_tag = 'main'
 
     create_release(ctx)
     determine_kokoro_job_name(ctx)

--- a/releasetool/commands/tag/nodejs.py
+++ b/releasetool/commands/tag/nodejs.py
@@ -195,11 +195,9 @@ def tag(ctx: TagContext = None) -> TagContext:
             return ctx
         get_release_notes(ctx)
     else:
-        # If using mono-release strategy, fallback to using the primary
-        # branch as the staging area for a publish.
-        # TODO(bcoe/chingor13): what are the ramifications of this,
-        # if a publish is delayed significantly.
-        ctx.release_tag = "main"
+        # If using mono-release strategy, fallback to using sha from
+        # time of merge:
+        ctx.release_tag = ctx.release_pr["merge_commit_sha"]
 
     create_release(ctx)
     determine_kokoro_job_name(ctx)

--- a/releasetool/commands/tag/nodejs.py
+++ b/releasetool/commands/tag/nodejs.py
@@ -123,7 +123,7 @@ def create_release(ctx: TagContext) -> None:
             [
                 # TODO(sofisl): remove pinning to a specific version
                 # once we've tested:
-                "npx@11.3.0-candidate.0",
+                "npx",
                 "release-please",
                 "manifest-release",
                 f"--token={token_file}",

--- a/releasetool/commands/tag/nodejs.py
+++ b/releasetool/commands/tag/nodejs.py
@@ -184,17 +184,18 @@ def tag(ctx: TagContext = None) -> TagContext:
     if ctx.release_pr is None:
         determine_release_pr(ctx)
 
-    determine_release_tag(ctx)
-    determine_package_version(ctx)
+    # If using manifest release, the manifest releaser determines
+    # release tag, version, and release notes:
+    if ctx.upstream_repo not in manifest_release:
+        determine_release_tag(ctx)
+        determine_package_version(ctx)
+        # If the release already exists, don't do anything
+        if releasetool.commands.common.release_exists(ctx):
+            click.secho(f"{ctx.release_tag} already exists.", fg="magenta")
+            return ctx
+        get_release_notes(ctx)
 
-    # If the release already exists, don't do anything
-    if releasetool.commands.common.release_exists(ctx):
-        click.secho(f"{ctx.release_tag} already exists.", fg="magenta")
-        return ctx
-
-    get_release_notes(ctx)
     create_release(ctx)
-
     determine_kokoro_job_name(ctx)
     releasetool.commands.common.publish_via_kokoro(ctx)
 


### PR DESCRIPTION
We should defer to the manifest releaser for creating CHANGELOG, determining version/tag.