### PR TITLE
refactor: extract kokoro_job_name into helper and add tests

### DIFF
--- a/releasetool/commands/tag/dotnet.py
+++ b/releasetool/commands/tag/dotnet.py
@@ -14,6 +14,7 @@
 
 import getpass
 import re
+from typing import Union
 
 import click
 
@@ -89,6 +90,19 @@ def create_releases(ctx: TagContext) -> None:
         ctx.release_pr, add=["autorelease: tagged"], remove=["autorelease: pending"]
     )
     releasetool.commands.common.publish_via_kokoro(ctx)
+
+
+def kokoro_job_name(upstream_repo: str, package_name: str) -> Union[str, None]:
+    """Return the Kokoro job name.
+
+    Args:
+        upstream_repo (str): The GitHub repo in the form of https://api.github.com/repos/<owner>/<repo>
+        package_name (str): The name of package to release
+
+    Returns:
+        The name of the Kokoro job to trigger or None if there is no job to trigger
+    """
+    return None
 
 
 # Note: unlike other languages, the .NET libraries may need multiple

--- a/releasetool/commands/tag/php.py
+++ b/releasetool/commands/tag/php.py
@@ -1,9 +1,23 @@
 import getpass
+from typing import Union
 
 import click
 
 import releasetool.commands.tag.nodejs
 from releasetool.commands.common import TagContext
+
+
+def kokoro_job_name(upstream_repo: str, package_name: str) -> Union[str, None]:
+    """Return the Kokoro job name.
+
+    Args:
+        upstream_repo (str): The GitHub repo in the form of `<owner>/<repo>`
+        package_name (str): The name of package to release
+
+    Returns:
+        The name of the Kokoro job to trigger or None if there is no job to trigger
+    """
+    return None
 
 
 def tag(ctx: TagContext = None) -> TagContext:

--- a/releasetool/commands/tag/python.py
+++ b/releasetool/commands/tag/python.py
@@ -14,6 +14,7 @@
 
 import getpass
 import re
+from typing import Union
 
 import click
 
@@ -116,6 +117,19 @@ def create_release(ctx: TagContext) -> None:
     )
 
 
+def kokoro_job_name(upstream_repo: str, package_name: str) -> Union[str, None]:
+    """Return the Kokoro job name.
+
+    Args:
+        upstream_repo (str): The GitHub repo in the form of `<owner>/<repo>`
+        package_name (str): The name of package to release
+
+    Returns:
+        The name of the Kokoro job to trigger or None if there is no job to trigger
+    """
+    return f"cloud-devrel/client-libraries/python/{upstream_repo}/release/release"
+
+
 def tag(ctx: TagContext = None) -> TagContext:
     if not ctx:
         ctx = TagContext()
@@ -141,9 +155,7 @@ def tag(ctx: TagContext = None) -> TagContext:
 
     create_release(ctx)
 
-    ctx.kokoro_job_name = (
-        f"cloud-devrel/client-libraries/python/{ctx.upstream_repo}/release/release"
-    )
+    ctx.kokoro_job_name = kokoro_job_name(ctx.upstream_repo, ctx.package_name)
     releasetool.commands.common.publish_via_kokoro(ctx)
 
     if ctx.interactive:

--- a/releasetool/commands/tag/python_tool.py
+++ b/releasetool/commands/tag/python_tool.py
@@ -14,6 +14,7 @@
 
 import getpass
 import re
+from typing import Union
 
 import click
 
@@ -62,6 +63,19 @@ def create_release(ctx: TagContext) -> None:
     )
 
 
+def kokoro_job_name(upstream_repo: str, package_name: str) -> Union[str, None]:
+    """Return the Kokoro job name.
+
+    Args:
+        upstream_repo (str): The GitHub repo in the form of `<owner>/<repo>`
+        package_name (str): The name of package to release
+
+    Returns:
+        The name of the Kokoro job to trigger or None if there is no job to trigger
+    """
+    return f"cloud-devrel/client-libraries/{package_name}/release"
+
+
 def tag(ctx: TagContext = None) -> TagContext:
     if not ctx:
         ctx = TagContext()
@@ -87,7 +101,7 @@ def tag(ctx: TagContext = None) -> TagContext:
 
     create_release(ctx)
 
-    ctx.kokoro_job_name = f"cloud-devrel/client-libraries/{ctx.package_name}/release"
+    ctx.kokoro_job_name = kokoro_job_name(ctx.upstream_repo, ctx.package_name)
     releasetool.commands.common.publish_via_kokoro(ctx)
 
     if ctx.interactive:

--- a/releasetool/commands/tag/ruby.py
+++ b/releasetool/commands/tag/ruby.py
@@ -14,6 +14,7 @@
 
 import getpass
 import re
+from typing import Union
 
 import click
 from requests import HTTPError
@@ -127,6 +128,25 @@ def create_release(ctx: TagContext) -> None:
     )
 
 
+def kokoro_job_name(upstream_repo: str, package_name: str) -> Union[str, None]:
+    """Return the Kokoro job name.
+
+    Args:
+        upstream_repo (str): The GitHub repo in the form of `<owner>/<repo>`
+        package_name (str): The name of package to release
+
+    Returns:
+        The name of the Kokoro job to trigger or None if there is no job to trigger
+    """
+    if "google-cloud-ruby" in upstream_repo:
+        job_name = package_name.split("google-cloud-")[-1]
+        return f"cloud-devrel/client-libraries/google-cloud-ruby/release/{job_name}"
+    elif "google-api-ruby-client" in upstream_repo:
+        return f"cloud-devrel/client-libraries/google-api-ruby-client/release/{package_name}"
+    else:
+        return f"cloud-devrel/client-libraries/{package_name}/release"
+
+
 def tag(ctx: TagContext = None) -> TagContext:
     if not ctx:
         ctx = TagContext()
@@ -153,18 +173,7 @@ def tag(ctx: TagContext = None) -> TagContext:
     get_release_notes(ctx)
 
     create_release(ctx)
-
-    if "google-cloud-ruby" in ctx.upstream_repo:
-        job_name = ctx.package_name.split("google-cloud-")[-1]
-        ctx.kokoro_job_name = (
-            f"cloud-devrel/client-libraries/google-cloud-ruby/release/{job_name}"
-        )
-    elif "google-api-ruby-client" in ctx.upstream_repo:
-        ctx.kokoro_job_name = f"cloud-devrel/client-libraries/google-api-ruby-client/release/{ctx.package_name}"
-    else:
-        ctx.kokoro_job_name = (
-            f"cloud-devrel/client-libraries/{ctx.package_name}/release"
-        )
+    ctx.kokoro_job_name = kokoro_job_name(ctx.upstream_repo, ctx.package_name)
 
     releasetool.commands.common.publish_via_kokoro(ctx)
 

--- a/tests/commands/tag/test_tag_dotnet.py
+++ b/tests/commands/tag/test_tag_dotnet.py
@@ -15,7 +15,7 @@
 import pytest
 import re
 
-from releasetool.commands.tag.dotnet import RELEASE_LINE_PATTERN
+from releasetool.commands.tag.dotnet import RELEASE_LINE_PATTERN, kokoro_job_name
 
 
 release_triggering_lines = [
@@ -54,3 +54,8 @@ def test_release_line_regex_not_matching(line):
     """
     match = re.search(RELEASE_LINE_PATTERN, line)
     assert match is None
+
+
+def test_kokoro_job_name():
+    job_name = kokoro_job_name("upstream-owner/upstream-repo", "some-package-name")
+    assert job_name is None

--- a/tests/commands/tag/test_tag_java.py
+++ b/tests/commands/tag/test_tag_java.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from releasetool.commands.tag.java import _parse_release_tag
+from releasetool.commands.tag.java import _parse_release_tag, kokoro_job_name
 
 RELEASE_PLEASE_OUTPUT = """
 ✔ creating release v1.20.0
@@ -26,3 +26,8 @@ RELEASE_PLEASE_OUTPUT = """
 def test_releasetool_release_tag():
     expected = "v1.20.0"
     assert _parse_release_tag(RELEASE_PLEASE_OUTPUT) == expected
+
+
+def test_kokoro_job_name():
+    job_name = kokoro_job_name("upstream-owner/upstream-repo", "some-package-name")
+    assert job_name == "cloud-devrel/client-libraries/java/upstream-repo/release/stage"

--- a/tests/commands/tag/test_tag_nodejs.py
+++ b/tests/commands/tag/test_tag_nodejs.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from releasetool.commands.tag.nodejs import _get_latest_release_notes
+from releasetool.commands.tag.nodejs import _get_latest_release_notes, kokoro_job_name
 from releasetool.commands.common import TagContext
 
 fixture_old_style_changelog = """
@@ -181,3 +181,11 @@ def test_extracts_appropriate_release_notes_when_prior_release_is_patch():
 * default temp directory to report directory ([#102](https://www.github.com/bcoe/c8/issues/102)) ([8602f4a](https://www.github.com/bcoe/c8/commit/8602f4a))
 * load .nycrc/.nycrc.json to simplify migration ([#100](https://www.github.com/bcoe/c8/issues/100)) ([bd7484f](https://www.github.com/bcoe/c8/commit/bd7484f))"""
     assert ctx.release_notes == expected
+
+
+def test_kokoro_job_name():
+    job_name = kokoro_job_name("upstream-owner/upstream-repo", "some-package-name")
+    assert (
+        job_name
+        == "cloud-devrel/client-libraries/nodejs/release/upstream-owner/upstream-repo/publish"
+    )

--- a/tests/commands/tag/test_tag_php.py
+++ b/tests/commands/tag/test_tag_php.py
@@ -1,0 +1,20 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from releasetool.commands.tag.php import kokoro_job_name
+
+
+def test_kokoro_job_name():
+    job_name = kokoro_job_name("upstream-owner/upstream-repo", "some-package-name")
+    assert job_name is None

--- a/tests/commands/tag/test_tag_python.py
+++ b/tests/commands/tag/test_tag_python.py
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from releasetool.commands.tag.python import kokoro_job_name
+
+
+def test_kokoro_job_name():
+    job_name = kokoro_job_name("upstream-owner/upstream-repo", "some-package-name")
+    assert (
+        job_name
+        == "cloud-devrel/client-libraries/python/upstream-owner/upstream-repo/release/release"
+    )

--- a/tests/commands/tag/test_tag_python_tool.py
+++ b/tests/commands/tag/test_tag_python_tool.py
@@ -1,0 +1,20 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from releasetool.commands.tag.python_tool import kokoro_job_name
+
+
+def test_kokoro_job_name():
+    job_name = kokoro_job_name("upstream-owner/upstream-repo", "some-package-name")
+    assert job_name == "cloud-devrel/client-libraries/some-package-name/release"

--- a/tests/commands/tag/test_tag_ruby.py
+++ b/tests/commands/tag/test_tag_ruby.py
@@ -1,0 +1,38 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from releasetool.commands.tag.ruby import kokoro_job_name
+
+
+def test_kokoro_job_name():
+    job_name = kokoro_job_name("upstream-owner/upstream-repo", "some-package-name")
+    assert job_name == "cloud-devrel/client-libraries/some-package-name/release"
+
+
+def test_kokoro_job_name_cloud():
+    job_name = kokoro_job_name(
+        "googleapis/google-cloud-ruby", "google-cloud-video-intelligence"
+    )
+    assert (
+        job_name
+        == "cloud-devrel/client-libraries/google-cloud-ruby/release/video-intelligence"
+    )
+
+
+def test_kokoro_job_name_apiary():
+    job_name = kokoro_job_name("googleapis/google-api-ruby-client", "youtube")
+    assert (
+        job_name
+        == "cloud-devrel/client-libraries/google-api-ruby-client/release/youtube"
+    )


### PR DESCRIPTION
Part of migration to use release-please for tagging, and limiting releasetool to triggering Kokoro jobs