### PR TITLE
feat: recognize x-version-update markers in ClientVersion.java

### DIFF
--- a/releasetool/commands/start/java.py
+++ b/releasetool/commands/start/java.py
@@ -39,6 +39,7 @@ VERSION_REPLACEMENT_FILENAMES = {
     "build.gradle": True,
     "dependencies.properties": True,
     "GoogleUtils.java": True,
+    "ClientVersion.java": True,
 }
 
 


### PR DESCRIPTION
It would be very useful to have a way for client developers to embed the project version inside a java class. 
There are currently 2 approaches that client devs can use:
1. read the jar manifest
2. use resource filtering to inject maven properties into a resource file

However both of these have limitations:
1. doesn't work when the client code is shaded into a parent uberjar
2. doesn't work when imported in g3

This new approach solves all of the limitations by allowing client devs to read it directly from a compiled class file which will always be available