### PR TITLE
fix(ruby): Trigger new Ruby release job from google-cloud-ruby

### DIFF
--- a/releasetool/commands/tag/ruby.py
+++ b/releasetool/commands/tag/ruby.py
@@ -139,8 +139,7 @@ def kokoro_job_name(upstream_repo: str, package_name: str) -> Union[str, None]:
         The name of the Kokoro job to trigger or None if there is no job to trigger
     """
     if "google-cloud-ruby" in upstream_repo:
-        job_name = package_name.split("google-cloud-")[-1]
-        return f"cloud-devrel/client-libraries/google-cloud-ruby/release/{job_name}"
+        return f"cloud-devrel/client-libraries/google-cloud-ruby/release"
     elif "google-api-ruby-client" in upstream_repo:
         return f"cloud-devrel/client-libraries/google-api-ruby-client/release/{package_name}"
     else:

--- a/releasetool/commands/tag/ruby.py
+++ b/releasetool/commands/tag/ruby.py
@@ -139,7 +139,7 @@ def kokoro_job_name(upstream_repo: str, package_name: str) -> Union[str, None]:
         The name of the Kokoro job to trigger or None if there is no job to trigger
     """
     if "google-cloud-ruby" in upstream_repo:
-        return f"cloud-devrel/client-libraries/google-cloud-ruby/release"
+        return "cloud-devrel/client-libraries/google-cloud-ruby/release"
     elif "google-api-ruby-client" in upstream_repo:
         return f"cloud-devrel/client-libraries/google-api-ruby-client/release/{package_name}"
     else:

--- a/tests/commands/tag/test_tag_ruby.py
+++ b/tests/commands/tag/test_tag_ruby.py
@@ -24,9 +24,7 @@ def test_kokoro_job_name_cloud():
     job_name = kokoro_job_name(
         "googleapis/google-cloud-ruby", "google-cloud-video-intelligence"
     )
-    assert (
-        job_name == "cloud-devrel/client-libraries/google-cloud-ruby/release"
-    )
+    assert job_name == "cloud-devrel/client-libraries/google-cloud-ruby/release"
 
 
 def test_kokoro_job_name_apiary():

--- a/tests/commands/tag/test_tag_ruby.py
+++ b/tests/commands/tag/test_tag_ruby.py
@@ -26,13 +26,13 @@ def test_kokoro_job_name_cloud():
     )
     assert (
         job_name
-        == "cloud-devrel/client-libraries/google-cloud-ruby/release/video-intelligence"
+        == "cloud-devrel/client-libraries/google-cloud-ruby/release"
     )
 
 
 def test_kokoro_job_name_apiary():
-    job_name = kokoro_job_name("googleapis/google-api-ruby-client", "youtube")
+    job_name = kokoro_job_name("googleapis/google-api-ruby-client", "google-apis-core")
     assert (
         job_name
-        == "cloud-devrel/client-libraries/google-api-ruby-client/release/youtube"
+        == "cloud-devrel/client-libraries/google-api-ruby-client/release/google-apis-core"
     )

--- a/tests/commands/tag/test_tag_ruby.py
+++ b/tests/commands/tag/test_tag_ruby.py
@@ -25,14 +25,13 @@ def test_kokoro_job_name_cloud():
         "googleapis/google-cloud-ruby", "google-cloud-video-intelligence"
     )
     assert (
-        job_name
-        == "cloud-devrel/client-libraries/google-cloud-ruby/release"
+        job_name == "cloud-devrel/client-libraries/google-cloud-ruby/release"
     )
 
 
 def test_kokoro_job_name_apiary():
-    job_name = kokoro_job_name("googleapis/google-api-ruby-client", "google-apis-core")
+    job_name = kokoro_job_name("googleapis/google-api-ruby-client", "youtube")
     assert (
         job_name
-        == "cloud-devrel/client-libraries/google-api-ruby-client/release/google-apis-core"
+        == "cloud-devrel/client-libraries/google-api-ruby-client/release/youtube"
     )


### PR DESCRIPTION
Ruby is reworking its release jobs for google-cloud-ruby. From this point, there will be a single release job shared by all libraries in the monorepo.

Please coordinate with dazuma internally before releasing.