### PR TITLE
fix(java): stop tagging java releases from autorelease

### DIFF
--- a/autorelease/tag.py
+++ b/autorelease/tag.py
@@ -22,7 +22,6 @@ import releasetool.github
 
 LANGUAGE_ALLOWLIST = [
     "dotnet",
-    "java",
     "nodejs",
     "php",
     "python_tool",

--- a/autorelease/trigger.py
+++ b/autorelease/trigger.py
@@ -17,7 +17,7 @@
 from autorelease import common, github, kokoro, reporter
 from releasetool.commands import tag
 
-LANGUAGE_ALLOWLIST = []
+LANGUAGE_ALLOWLIST = ["java"]
 ORGANIZATIONS_TO_SCAN = ["googleapis", "GoogleCloudPlatform"]
 
 

--- a/tests/test_autorelease_tag.py
+++ b/tests/test_autorelease_tag.py
@@ -81,6 +81,7 @@ def test_process_issue_skips_non_merged(run_releasetool_tag):
     run_releasetool_tag.assert_not_called()
 
 
+@patch("autorelease.tag.LANGUAGE_ALLOWLIST", ["java"])
 @patch("autorelease.kokoro.trigger_build")
 @patch("autorelease.tag.run_releasetool_tag")
 def test_process_issue_triggers_kokoro(run_releasetool_tag, trigger_build):
@@ -103,6 +104,7 @@ def test_process_issue_triggers_kokoro(run_releasetool_tag, trigger_build):
     trigger_build.assert_called_once()
 
 
+@patch("autorelease.tag.LANGUAGE_ALLOWLIST", ["java"])
 @patch("autorelease.kokoro.trigger_build")
 @patch("autorelease.tag.run_releasetool_tag")
 def test_process_issue_skips_kokoro_if_no_job_name(run_releasetool_tag, trigger_build):


### PR DESCRIPTION
We will want to sync this with the rollout of updates to release-please configs in the Java repos. Wait for https://github.com/googleapis/synthtool/pull/1064 to roll out to all the Java repos