### PR TITLE
fix(java): allow java builds in autorelease.trigger

### DIFF
--- a/autorelease/trigger.py
+++ b/autorelease/trigger.py
@@ -17,7 +17,7 @@
 from autorelease import common, github, kokoro, reporter
 from releasetool.commands import tag
 
-LANGUAGE_ALLOWLIST = []
+LANGUAGE_ALLOWLIST = ["java"]
 ORGANIZATIONS_TO_SCAN = ["googleapis", "GoogleCloudPlatform"]
 
 


### PR DESCRIPTION
This is part of go/deprecate-autorelease-tag where we switch from autorelease tagging to release-please tagging.

This will all autorelease to start triggering Kokoro off of `autorelease: tagged`