### PR TITLE
fix: revert to using importlib for dynamic module loading

### DIFF
--- a/autorelease/trigger.py
+++ b/autorelease/trigger.py
@@ -14,8 +14,9 @@
 
 """This module handles triggering Kokoro release jobs for merged release pull requests."""
 
+import importlib
+
 from autorelease import common, github, kokoro, reporter
-from releasetool.commands import tag
 
 LANGUAGE_ALLOWLIST = ["java"]
 ORGANIZATIONS_TO_SCAN = ["googleapis", "GoogleCloudPlatform"]
@@ -56,7 +57,7 @@ def trigger_kokoro_build_for_pull_request(
         result.print(f"Language {lang} not in allowlist, skipping.")
         return
 
-    language_module = getattr(tag, lang)
+    language_module = importlib.import_module(f"releasetool.commands.tag.{lang}")
     package_name = language_module.package_name(pull)
     kokoro_job_name = language_module.kokoro_job_name(
         pull["base"]["repo"]["full_name"], package_name


### PR DESCRIPTION
Fixes #325 

This is the method for dynamic module loading used in the `tag` job - the `getattr` method looks cleaner, but is failing at runtime (but not test time?)

See https://github.com/googleapis/releasetool/pull/314#discussion_r620607966