### PR TITLE
fix: only trigger Kokoro jobs once

### DIFF
--- a/autorelease/trigger.py
+++ b/autorelease/trigger.py
@@ -51,6 +51,13 @@ def trigger_kokoro_build_for_pull_request(
         )
         return
 
+    # If the Kokoro job has already been triggered, don't trigger again.
+    if "labels" in pull and any(
+        "name" in label and label["name"] == "autorelease: triggered"
+        for label in pull["labels"]
+    ):
+        return
+
     # Determine language.
     lang = common.guess_language(gh, pull["base"]["repo"]["full_name"])
 
@@ -82,6 +89,7 @@ def trigger_kokoro_build_for_pull_request(
         sha=sha,
         env_vars={"AUTORELEASE_PR": pull_request_url},
     )
+    gh.update_pull_labels(pull, add=["autorelease: triggered"])
 
 
 def main(github_token, kokoro_credentials) -> reporter.Reporter:

--- a/tests/test_autorelease_trigger.py
+++ b/tests/test_autorelease_trigger.py
@@ -96,6 +96,7 @@ def test_trigger_kokoro_build_for_pull_request_triggers_kokoro(trigger_build):
 
     trigger.trigger_kokoro_build_for_pull_request(Mock(), github, issue, Mock())
     trigger_build.assert_called_once()
+    github.update_pull_labels.assert_called_once()
 
 
 @patch("autorelease.trigger.LANGUAGE_ALLOWLIST", [])
@@ -128,6 +129,28 @@ def test_trigger_kokoro_build_for_pull_request_skips_kokoro_if_no_job_name(
         "merged_at": "2021-01-01T09:00:00.000Z",
         "base": {"repo": {"full_name": "googleapis/google-cloud-php"}},
         "html_url": "https://github.com/googleapis/google-cloud-php/pulls/5",
+    }
+    issue = {
+        "pull_request": {
+            "url": "https://api.github.com/googleapis/google-cloud-php/pull/5"
+        },
+        "merged_at": "2021-01-01T09:00:00.000Z",
+    }
+    trigger.trigger_kokoro_build_for_pull_request(Mock(), github, issue, Mock())
+    trigger_build.assert_not_called()
+
+
+@patch("autorelease.trigger.LANGUAGE_ALLOWLIST", ["php"])
+@patch("autorelease.kokoro.trigger_build")
+def test_trigger_kokoro_build_for_pull_request_skips_kokoro_if_already_triggered(
+    trigger_build,
+):
+    github = Mock()
+    github.get_url.return_value = {
+        "merged_at": "2021-01-01T09:00:00.000Z",
+        "base": {"repo": {"full_name": "googleapis/google-cloud-php"}},
+        "html_url": "https://github.com/googleapis/google-cloud-php/pulls/5",
+        "labels": [{"id": 12345, "name": "autorelease: triggered"}],
     }
     issue = {
         "pull_request": {


### PR DESCRIPTION
Fixes #330

This approach adds a label to the tagged release PR to indicate we have already triggered the release build. To retry for the next time, a maintainer can remove the `autorelease: triggered` label.