### PR TITLE
fix: include jinja template in released package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,4 +65,8 @@ setuptools.setup(
     entry_points={
         'console_scripts': scripts,
     },
+    package_data={
+        'autorelease': ['autorelease/*.j2']
+    },
+    include_package_data=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -68,5 +68,4 @@ setuptools.setup(
     package_data={
         'autorelease': ['autorelease/*.j2']
     },
-    include_package_data=True,
 )


### PR DESCRIPTION
The published package on pypi is missing the report.xml.j2 file.