### PR TITLE
feat: add command for triggering a single kokoro job by PR url

### DIFF
--- a/autorelease/__main__.py
+++ b/autorelease/__main__.py
@@ -46,6 +46,7 @@ def main():
     parser.add_argument(
         "--kokoro-credentials", default=os.environ.get("AUTORELEASE_KOKORO_CREDENTIALS")
     )
+    parser.add_argument("--pull", default=None)
     parser.add_argument("command")
 
     args = parser.parse_args()
@@ -64,6 +65,20 @@ def main():
             return
     elif args.command == "trigger":
         report = trigger.main(args.github_token, args.kokoro_credentials)
+
+        if args.report:
+            report.write(args.report)
+
+        if report.failures:
+            sys.exit(2)
+        else:
+            return
+    elif args.command == "trigger-single":
+        if not args.pull:
+            raise Exception("missing required arg --pull")
+        report = trigger.trigger_single(
+            args.github_token, args.kokoro_credentials, args.pull
+        )
 
         if args.report:
             report.write(args.report)

--- a/autorelease/github.py
+++ b/autorelease/github.py
@@ -178,6 +178,12 @@ class GitHub:
         response.raise_for_status()
         return base64.b64decode(response.json()["content"])
 
+    def get_issue(self, repository: str, number: int) -> dict:
+        url = f"{self.GITHUB_ROOT}/repos/{repository}/issues/{number}"
+        response = self.session.get(url)
+        response.raise_for_status()
+        return response.json()
+
     def list_files(self, repository: str, path: str, ref: str = None) -> Sequence[dict]:
         url = f"{self.GITHUB_ROOT}/repos/{repository}/contents/{path}"
         response = self.session.get(url, params={"ref": ref})

--- a/autorelease/trigger.py
+++ b/autorelease/trigger.py
@@ -121,7 +121,7 @@ def trigger_single(
             f"Processing {issue['title']}: {issue['pull_request']['html_url']}"
         )
         report.add(result)
-    except:
+    except Exception:
         result = reporter.Result(pull_request_url, error=True)
         result.print(f"Error fetching pull request: {pull_request_url}")
         report.add(result)

--- a/autorelease/trigger.py
+++ b/autorelease/trigger.py
@@ -113,11 +113,19 @@ def trigger_single(
     else:
         kokoro_session = kokoro.make_adc_session()
 
-    repository, number = _parse_issue(pull_request_url)
-    issue = gh.get_issue(repository, number)
-    result = reporter.Result(f"{issue['title']}")
-    report.add(result)
-    result.print(f"Processing {issue['title']}: {issue['pull_request']['html_url']}")
+    try:
+        repository, number = _parse_issue(pull_request_url)
+        issue = gh.get_issue(repository, number)
+        result = reporter.Result(f"{issue['title']}")
+        result.print(
+            f"Processing {issue['title']}: {issue['pull_request']['html_url']}"
+        )
+        report.add(result)
+    except:
+        result = reporter.Result(pull_request_url, error=True)
+        result.print(f"Error fetching pull request: {pull_request_url}")
+        report.add(result)
+        return report
 
     try:
         trigger_kokoro_build_for_pull_request(kokoro_session, gh, issue, result)

--- a/autorelease/trigger.py
+++ b/autorelease/trigger.py
@@ -29,7 +29,7 @@ CREATED_AFTER = "2021-04-01"
 
 
 def trigger_kokoro_build_for_pull_request(
-    kokoro_session, gh: github.GitHub, issue: dict, result
+    kokoro_session, gh: github.GitHub, issue: dict, result, update_labels: bool = True
 ) -> None:
     """Triggers the Kokoro job for a given pull request if possible.
 
@@ -91,7 +91,8 @@ def trigger_kokoro_build_for_pull_request(
         sha=sha,
         env_vars={"AUTORELEASE_PR": pull_request_url},
     )
-    gh.update_pull_labels(pull, add=["autorelease: triggered"])
+    if update_labels:
+        gh.update_pull_labels(pull, add=["autorelease: triggered"])
 
 
 def _parse_issue(pull_request_url: str) -> Tuple[str, int]:
@@ -128,7 +129,7 @@ def trigger_single(
         return report
 
     try:
-        trigger_kokoro_build_for_pull_request(kokoro_session, gh, issue, result)
+        trigger_kokoro_build_for_pull_request(kokoro_session, gh, issue, result, False)
     # Failing any one PR is fine, just record it in the log and continue.
     except Exception as exc:
         result.error = True

--- a/tests/test_autorelease_trigger.py
+++ b/tests/test_autorelease_trigger.py
@@ -171,3 +171,97 @@ def test_trigger_kokoro_build_for_pull_request_skips_kokoro_if_already_triggered
     }
     trigger.trigger_kokoro_build_for_pull_request(Mock(), github, issue, Mock())
     trigger_build.assert_not_called()
+
+
+@patch("autorelease.kokoro.make_authorized_session")
+@patch("autorelease.github.GitHub.get_issue")
+@patch("autorelease.github.GitHub.get_url")
+@patch("autorelease.github.GitHub.update_pull_labels")
+@patch("autorelease.kokoro.trigger_build")
+def test_trigger_single(
+    trigger_build, update_pull_labels, get_url, get_issue, make_authorized_session
+):
+    kokoro_session = Mock()
+    make_authorized_session.return_value = kokoro_session
+    get_issue.return_value = {
+        "title": "chore: release 1.2.3",
+        "pull_request": {
+            "html_url": "https://github.com/googleapis/java-trace/pull/1234",
+            "url": "https://api.github.com/repos/googleapis/java-trace/pulls/1234",
+        },
+    }
+    get_url.return_value = {
+        "merged_at": "2021-07-20T09:00:00.123Z",
+        "base": {"repo": {"full_name": "googleapis/java-trace"}},
+        "html_url": "https://github.com/googleapis/java-trace/pull/1234",
+        "merge_commit_sha": "abcd1234",
+        "labels": [{"id": 12345, "name": "autorelease: tagged"}],
+    }
+
+    pull_request_url = "https://github.com/googleapis/java-trace/pull/1234"
+    reporter = trigger.trigger_single(
+        "fake-github-token", "fake-kokoro-credentials", pull_request_url
+    )
+
+    assert len(reporter.results) == 1
+    trigger_build.assert_called_with(
+        kokoro_session,
+        job_name="cloud-devrel/client-libraries/java/java-trace/release/stage",
+        sha="abcd1234",
+        env_vars={
+            "AUTORELEASE_PR": "https://github.com/googleapis/java-trace/pull/1234"
+        },
+    )
+    update_pull_labels.assert_called_once()
+
+
+@patch("autorelease.kokoro.make_authorized_session")
+@patch("autorelease.kokoro.trigger_build")
+def test_trigger_single_bad_url(trigger_build, make_authorized_session):
+    kokoro_session = Mock()
+    make_authorized_session.return_value = kokoro_session
+
+    pull_request_url = "https://github.com/googleapis/java-trace/issues/1234"
+    reporter = trigger.trigger_single(
+        "fake-github-token", "fake-kokoro-credentials", pull_request_url
+    )
+
+    assert len(reporter.results) == 1
+    trigger_build.assert_not_called()
+
+
+@patch("autorelease.kokoro.make_authorized_session")
+@patch("autorelease.github.GitHub.get_issue")
+@patch("autorelease.github.GitHub.get_url")
+@patch("autorelease.github.GitHub.update_pull_labels")
+@patch("autorelease.kokoro.trigger_build")
+def test_trigger_single_skips_already_triggered(
+    trigger_build, update_pull_labels, get_url, get_issue, make_authorized_session
+):
+    kokoro_session = Mock()
+    make_authorized_session.return_value = kokoro_session
+    get_issue.return_value = {
+        "title": "chore: release 1.2.3",
+        "pull_request": {
+            "html_url": "https://github.com/googleapis/java-trace/pull/1234",
+            "url": "https://api.github.com/repos/googleapis/java-trace/pulls/1234",
+        },
+    }
+    get_url.return_value = {
+        "merged_at": "2021-07-20T09:00:00.123Z",
+        "base": {"repo": {"full_name": "googleapis/java-trace"}},
+        "html_url": "https://github.com/googleapis/java-trace/pull/1234",
+        "merge_commit_sha": "abcd1234",
+        "labels": [
+            {"id": 12345, "name": "autorelease: tagged"},
+            {"id": 12346, "name": "autorelease: triggered"},
+        ],
+    }
+
+    pull_request_url = "https://github.com/googleapis/java-trace/pull/1234"
+    reporter = trigger.trigger_single(
+        "fake-github-token", "fake-kokoro-credentials", pull_request_url
+    )
+
+    assert len(reporter.results) == 1
+    trigger_build.assert_not_called()

--- a/tests/test_autorelease_trigger.py
+++ b/tests/test_autorelease_trigger.py
@@ -212,7 +212,7 @@ def test_trigger_single(
             "AUTORELEASE_PR": "https://github.com/googleapis/java-trace/pull/1234"
         },
     )
-    update_pull_labels.assert_called_once()
+    update_pull_labels.assert_not_called()
 
 
 @patch("autorelease.kokoro.make_authorized_session")


### PR DESCRIPTION
This is an extra command to trigger a single release. The purpose of this command is to allow other mechanism for triggering the kokoro build without having to rewrite the proto2 -> pubsub logic.