### PR TITLE
fix: fix path in setup.py for template files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,6 @@ setuptools.setup(
         'console_scripts': scripts,
     },
     package_data={
-        'autorelease': ['autorelease/*.j2']
+        'autorelease': ['*.j2']
     },
 )


### PR DESCRIPTION
The path doesn't include the package name.

Tested by doing an install from git in a docker container:
`git+git://github.com/chingor13/releasetool@fix-missing-template#egg=releasetool` and the installed package now has the jinja template available.