### PR TITLE
fix: stop handling java repos

### DIFF
--- a/autorelease/tag.py
+++ b/autorelease/tag.py
@@ -22,7 +22,6 @@ import releasetool.github
 
 LANGUAGE_ALLOWLIST = [
     "dotnet",
-    "java",
     "nodejs",
     "php",
     "python_tool",

--- a/autorelease/trigger.py
+++ b/autorelease/trigger.py
@@ -20,7 +20,7 @@ from typing import Tuple
 
 from autorelease import common, github, kokoro, reporter
 
-LANGUAGE_ALLOWLIST = ["java", "nodejs"]
+LANGUAGE_ALLOWLIST = ["nodejs"]
 ORGANIZATIONS_TO_SCAN = ["googleapis", "GoogleCloudPlatform"]
 
 # Whenever we add new languages to the allowlist, update this value as

--- a/tests/test_autorelease_tag.py
+++ b/tests/test_autorelease_tag.py
@@ -81,6 +81,7 @@ def test_process_issue_skips_non_merged(run_releasetool_tag):
     run_releasetool_tag.assert_not_called()
 
 
+@patch("autorelease.tag.LANGUAGE_ALLOWLIST", ["java"])
 @patch("autorelease.kokoro.trigger_build")
 @patch("autorelease.tag.run_releasetool_tag")
 def test_process_issue_triggers_kokoro(run_releasetool_tag, trigger_build):
@@ -103,6 +104,7 @@ def test_process_issue_triggers_kokoro(run_releasetool_tag, trigger_build):
     trigger_build.assert_called_once()
 
 
+@patch("autorelease.tag.LANGUAGE_ALLOWLIST", ["java"])
 @patch("autorelease.kokoro.trigger_build")
 @patch("autorelease.tag.run_releasetool_tag")
 def test_process_issue_skips_kokoro_if_no_job_name(run_releasetool_tag, trigger_build):

--- a/tests/test_autorelease_trigger.py
+++ b/tests/test_autorelease_trigger.py
@@ -173,6 +173,7 @@ def test_trigger_kokoro_build_for_pull_request_skips_kokoro_if_already_triggered
     trigger_build.assert_not_called()
 
 
+@patch("autorelease.trigger.LANGUAGE_ALLOWLIST", ["java"])
 @patch("autorelease.kokoro.make_authorized_session")
 @patch("autorelease.github.GitHub.get_issue")
 @patch("autorelease.github.GitHub.get_url")


### PR DESCRIPTION
 They are migrated to release-please/release-trigger

Fixes #361
Fixes https://github.com/googleapis/repo-automation-bots/issues/2442
Fixes #343
Fixes #336 