### PR TITLE
fix(nodejs): stop autorelease for nodejs

### DIFF
--- a/autorelease/tag.py
+++ b/autorelease/tag.py
@@ -22,7 +22,6 @@ import releasetool.github
 
 LANGUAGE_ALLOWLIST = [
     "dotnet",
-    "nodejs",
     "php",
     "python_tool",
     "python",

--- a/autorelease/trigger.py
+++ b/autorelease/trigger.py
@@ -20,7 +20,7 @@ from typing import Tuple
 
 from autorelease import common, github, kokoro, reporter
 
-LANGUAGE_ALLOWLIST = ["nodejs"]
+LANGUAGE_ALLOWLIST = []
 ORGANIZATIONS_TO_SCAN = ["googleapis", "GoogleCloudPlatform"]
 
 # Whenever we add new languages to the allowlist, update this value as


### PR DESCRIPTION
After all repositories have been updated to use the release-trigger app, we can stop triggering nodejs jobs with the autorelease cron.