### PR TITLE
build: remove deprecated backend_type config

### DIFF
--- a/.kokoro-autorelease/common.cfg
+++ b/.kokoro-autorelease/common.cfg
@@ -45,8 +45,6 @@ before_action {
     keystore_resource {
       keystore_config_id: 73713
       keyname: "autorelease-magictoken"
-      # TODO(busunkim): remove this after secrets have globally propagated
-      backend_type: FASTCONFIGPUSH
     }
   }
 }
@@ -58,7 +56,6 @@ before_action {
     keystore_resource {
       keystore_config_id: 73713
       keyname: "yoshi-automation-github-key"
-      backend_type: FASTCONFIGPUSH
     }
   }
 }
@@ -69,8 +66,6 @@ before_action {
     keystore_resource {
       keystore_config_id: 73713
       keyname: "magic-github-proxy-api-key"
-      # TODO(busunkim): remove this after secrets have globally propagated
-      backend_type: FASTCONFIGPUSH
     }
   }
 }

--- a/.kokoro-autorelease/tag.cfg
+++ b/.kokoro-autorelease/tag.cfg
@@ -17,7 +17,6 @@ before_action {
     keystore_resource {
       keystore_config_id: 73713
       keyname: "kokoro_trigger_credentials"
-      backend_type: FASTCONFIGPUSH
     }
   }
 }

--- a/.kokoro-autorelease/trigger.cfg
+++ b/.kokoro-autorelease/trigger.cfg
@@ -17,7 +17,6 @@ before_action {
     keystore_resource {
       keystore_config_id: 73713
       keyname: "kokoro_trigger_credentials"
-      backend_type: FASTCONFIGPUSH
     }
   }
 }


### PR DESCRIPTION
It should be enough to remove the `backend_type` for now, this is how Node.js has their `keystore_resource` configured and tests are not failing.

@chingor13 has put work in to retire this repository, anyone on `release-please` will eventually be able to migrate away from `releasetool`. tldr; I'm tempted to hold off on retiring these secrets, in favor of retiring this repo next quarter.

Refs: #369