### PR TITLE
fix(ruby): Remove hack pointing at legacy release jobs for the Ruby Apiary clients repo

### DIFF
--- a/releasetool/commands/tag/ruby.py
+++ b/releasetool/commands/tag/ruby.py
@@ -167,10 +167,6 @@ def kokoro_job_name(upstream_repo: str, package_name: str) -> Union[str, None]:
         The name of the Kokoro job to trigger or None if there is no job to trigger
     """
 
-    # TODO(dazuma): Remove once this repo uses the standard release jobs
-    if "google-api-ruby-client" in upstream_repo:
-        return f"cloud-devrel/client-libraries/google-api-ruby-client/release/{package_name}"
-
     for name in RUBY_CLIENT_REPOS:
         if name in upstream_repo:
             return f"cloud-devrel/client-libraries/{name}/release"


### PR DESCRIPTION
This hack pointed to legacy release jobs for the Ruby apiary repo (googleapis/google-api-ruby-client) while the new standard Ruby release jobs were being tested. We are switching over to the standard jobs now by removing the hack.