### PR TITLE
build: try to fix python install from GitHub

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ jinja2
 attrs
 protobuf
 google-auth
-git+git://github.com/GoogleCloudPlatform/releasetool.git@master#egg=gcp-releasetool
+git+https://github.com/GoogleCloudPlatform/releasetool.git@master#egg=gcp-releasetool

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ jinja2
 attrs
 protobuf
 google-auth
-git+https://github.com/GoogleCloudPlatform/releasetool.git@master#egg=gcp-releasetool
+git+https://github.com/googleapis/releasetool.git@master#egg=gcp-releasetool


### PR DESCRIPTION
git:// protocol seems to be deprecated.

see: https://github.blog/2021-09-01-improving-git-protocol-security-github/