### PR TITLE
fix: stop running autorelease tag for php and python_tool

### DIFF
--- a/autorelease/tag.py
+++ b/autorelease/tag.py
@@ -22,8 +22,6 @@ import releasetool.github
 
 LANGUAGE_ALLOWLIST = [
     "dotnet",
-    "php",
-    "python_tool",
     "ruby",
 ]
 


### PR DESCRIPTION
PHP is using release-please for tagging releases
python_tool is no longer used (synthtool does not create releases)