### PR TITLE
fix: implement kokoro_job_name helper for dotnet

### DIFF
--- a/releasetool/commands/tag/dotnet.py
+++ b/releasetool/commands/tag/dotnet.py
@@ -104,7 +104,8 @@ def kokoro_job_name(upstream_repo: str, package_name: str) -> Union[str, None]:
     Returns:
         The name of the Kokoro job to trigger or None if there is no job to trigger
     """
-    return None
+    repo_short_name = upstream_repo.split("/")[-1]
+    return f"cloud-sharp/{repo_short_name}/gcp_windows/autorelease"
 
 
 def package_name(pull: dict) -> Union[str, None]:

--- a/tests/commands/tag/test_tag_dotnet.py
+++ b/tests/commands/tag/test_tag_dotnet.py
@@ -62,7 +62,7 @@ def test_release_line_regex_not_matching(line):
 
 def test_kokoro_job_name():
     job_name = kokoro_job_name("upstream-owner/upstream-repo", "some-package-name")
-    assert job_name is None
+    assert job_name == "cloud-sharp/upstream-repo/gcp_windows/autorelease"
 
 
 def test_package_name():


### PR DESCRIPTION
`release-trigger` is currently unable to trigger dotnet release jobs as it does not know how to build the Kokoro release job name given the repository name.

Example from the logs:
```
Processing chore(main): release Google.CloudEvents.Protobuf 1.2.0: https://github.com/googleapis/google-cloudevents-dotnet/pull/126
No Kokoro job for https://github.com/googleapis/google-cloudevents-dotnet/pull/126, skipping.
```