### PR TITLE
fix: Configure kokoro jobs for functions-framework-java release 

### DIFF
--- a/releasetool/commands/tag/java.py
+++ b/releasetool/commands/tag/java.py
@@ -56,10 +56,7 @@ def kokoro_job_name(upstream_repo: str, package_name: str) -> Union[str, None]:
         return f"cloud-java-frameworks/{repo_short_name}/stage"
 
     if repo_short_name == "functions-framework-java" and package_name in functions_framework_java_packages:
-        if package_name == "java-function-invoker":
-            return f"functions-framework/java/invoker/release"
-        else:
-            return f"functions-framework/java/{package_name}/release"
+        return f"functions-framework/java/{package_name}/release"
 
     else:
         return f"cloud-devrel/client-libraries/java/{repo_short_name}/release/stage"

--- a/releasetool/commands/tag/java.py
+++ b/releasetool/commands/tag/java.py
@@ -38,7 +38,7 @@ def _parse_release_tag(output: str) -> str:
 """
 # Standard Java Framework repos in the GoogleCloudPlatform org
 java_framework_release_pool_repos: List[str] = ["google-cloud-spanner-hibernate"]
-functions_framework_java_packages: List[str] = ["functions-framework-api", "invoker", "function-maven-plugin"]
+functions_framework_java_packages: List[str] = ["functions-framework-api", "java-function-invoker", "function-maven-plugin"]
 
 def kokoro_job_name(upstream_repo: str, package_name: str) -> Union[str, None]:
     """Return the Kokoro job name.
@@ -56,13 +56,20 @@ def kokoro_job_name(upstream_repo: str, package_name: str) -> Union[str, None]:
         return f"cloud-java-frameworks/{repo_short_name}/stage"
 
     if repo_short_name == "functions-framework-java" and package_name in functions_framework_java_packages:
-        return f"functions-framework/java/{package_name}/release"
+        if package_name == "java-function-invoker":
+            return f"functions-framework/java/invoker/release"
+        else:
+            return f"functions-framework/java/{package_name}/release"
 
     else:
         return f"cloud-devrel/client-libraries/java/{repo_short_name}/release/stage"
 
 
 def package_name(pull: dict) -> Union[str, None]:
+    title = pull["title"]
+    match = re.search(".* release (.*) [0-9].*", title)
+    if match:
+        return match[1]
     return None
 
 

--- a/releasetool/commands/tag/java.py
+++ b/releasetool/commands/tag/java.py
@@ -38,7 +38,12 @@ def _parse_release_tag(output: str) -> str:
 """
 # Standard Java Framework repos in the GoogleCloudPlatform org
 java_framework_release_pool_repos: List[str] = ["google-cloud-spanner-hibernate"]
-functions_framework_java_packages: List[str] = ["functions-framework-api", "java-function-invoker", "function-maven-plugin"]
+functions_framework_java_packages: List[str] = [
+    "functions-framework-api",
+    "java-function-invoker",
+    "function-maven-plugin",
+]
+
 
 def kokoro_job_name(upstream_repo: str, package_name: str) -> Union[str, None]:
     """Return the Kokoro job name.
@@ -55,7 +60,10 @@ def kokoro_job_name(upstream_repo: str, package_name: str) -> Union[str, None]:
     if repo_short_name in java_framework_release_pool_repos:
         return f"cloud-java-frameworks/{repo_short_name}/stage"
 
-    if repo_short_name == "functions-framework-java" and package_name in functions_framework_java_packages:
+    if (
+        repo_short_name == "functions-framework-java"
+        and package_name in functions_framework_java_packages
+    ):
         return f"functions-framework/java/{package_name}/release"
 
     else:

--- a/releasetool/commands/tag/java.py
+++ b/releasetool/commands/tag/java.py
@@ -66,10 +66,11 @@ def kokoro_job_name(upstream_repo: str, package_name: str) -> Union[str, None]:
 
 
 def package_name(pull: dict) -> Union[str, None]:
-    title = pull["title"]
-    match = re.search(".* release (.*) [0-9].*", title)
-    if match:
-        return match[1]
+    if pull.__contains__("title"):
+        title = pull["title"]
+        match = re.search(".* release (.*) [0-9].*", title)
+        if match:
+            return match[1]
     return None
 
 

--- a/releasetool/commands/tag/java.py
+++ b/releasetool/commands/tag/java.py
@@ -38,7 +38,7 @@ def _parse_release_tag(output: str) -> str:
 """
 # Standard Java Framework repos in the GoogleCloudPlatform org
 java_framework_release_pool_repos: List[str] = ["google-cloud-spanner-hibernate"]
-
+functions_framework_java_packages: List[str] = ["functions-framework-api", "invoker", "function-maven-plugin"]
 
 def kokoro_job_name(upstream_repo: str, package_name: str) -> Union[str, None]:
     """Return the Kokoro job name.
@@ -54,6 +54,9 @@ def kokoro_job_name(upstream_repo: str, package_name: str) -> Union[str, None]:
 
     if repo_short_name in java_framework_release_pool_repos:
         return f"cloud-java-frameworks/{repo_short_name}/stage"
+
+    if repo_short_name == "functions-framework-java" and package_name in functions_framework_java_packages:
+        return f"functions-framework/java/{package_name}/release.cfg"
 
     else:
         return f"cloud-devrel/client-libraries/java/{repo_short_name}/release/stage"

--- a/releasetool/commands/tag/java.py
+++ b/releasetool/commands/tag/java.py
@@ -56,7 +56,7 @@ def kokoro_job_name(upstream_repo: str, package_name: str) -> Union[str, None]:
         return f"cloud-java-frameworks/{repo_short_name}/stage"
 
     if repo_short_name == "functions-framework-java" and package_name in functions_framework_java_packages:
-        return f"functions-framework/java/{package_name}/release.cfg"
+        return f"functions-framework/java/{package_name}/release"
 
     else:
         return f"cloud-devrel/client-libraries/java/{repo_short_name}/release/stage"

--- a/tests/test_autorelease_trigger.py
+++ b/tests/test_autorelease_trigger.py
@@ -245,7 +245,7 @@ def test_trigger_package(
     trigger.trigger_kokoro_build_for_pull_request(kokoro_session, github, issue, Mock())
     trigger_build.assert_called_with(
         kokoro_session,
-        job_name="functions-framework/java/invoker/release",
+        job_name="functions-framework/java/java-function-invoker/release",
         sha="abcd111",
         env_vars={
             "AUTORELEASE_PR": "https://github.com/GoogleCloudPlatform/functions-framework-java/pull/111"

--- a/tests/test_autorelease_trigger.py
+++ b/tests/test_autorelease_trigger.py
@@ -225,29 +225,24 @@ def test_trigger_single(
 def test_trigger_package(
     trigger_build, update_pull_labels, get_url, get_issue, make_authorized_session
 ):
+    github = Mock()
     kokoro_session = Mock()
-    make_authorized_session.return_value = kokoro_session
-    get_issue.return_value = {
-        "title": "chore(master): release java-function-invoker 1.1.2",
-        "pull_request": {
-            "html_url": "https://github.com/GoogleCloudPlatform/functions-framework-java/pull/111",
-            "url": "https://api.github.com/repos/GoogleCloudPlatform/functions-framework-java/pulls/111",
-        },
-    }
-    get_url.return_value = {
-        "merged_at": "2021-07-20T09:00:00.123Z",
+    github.get_url.return_value = {
+        "merged_at": "2021-01-01T09:00:00.000Z",
         "base": {"repo": {"full_name": "GoogleCloudPlatform/functions-framework-java"}},
         "html_url": "https://github.com/GoogleCloudPlatform/functions-framework-java/pull/111",
-        "merge_commit_sha": "abcd111",
         "labels": [{"id": 111, "name": "autorelease: tagged"}],
+        "merge_commit_sha": "abcd111",
+        "title": "chore(master): release java-function-invoker 1.1.2",
+    }
+    issue = {
+        "pull_request": {
+            "url": "https://api.github.com/repos/GoogleCloudPlatform/functions-framework-java/pulls/111"
+        },
+        "merged_at": "2021-01-01T09:00:00.000Z",
     }
 
-    pull_request_url = "https://github.com/GoogleCloudPlatform/functions-framework-java/pull/111"
-    reporter = trigger.trigger_single(
-        "fake-github-token", "fake-kokoro-credentials", pull_request_url
-    )
-
-    assert len(reporter.results) == 1
+    trigger.trigger_kokoro_build_for_pull_request(kokoro_session, github, issue, Mock())
     trigger_build.assert_called_with(
         kokoro_session,
         job_name="functions-framework/java/invoker/release",
@@ -256,7 +251,6 @@ def test_trigger_package(
             "AUTORELEASE_PR": "https://github.com/GoogleCloudPlatform/functions-framework-java/pull/111"
         },
     )
-    update_pull_labels.assert_not_called()
 
 
 @patch("autorelease.kokoro.make_authorized_session")


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/functions-framework-java has three different packages which use different kokoro jobs. Adding the configuration for the same