### PR TITLE
fix(ruby): check repo name exact match

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -15,13 +15,13 @@
 import nox
 
 
-@nox.session(python='3.6')
+@nox.session(python='3.8')
 def blacken(session):
     session.install('black')
     session.run('black', 'autorelease', 'releasetool', 'tests')
 
 
-@nox.session(python='3.6')
+@nox.session(python='3.8')
 def lint(session):
     session.install('mypy==0.812', 'flake8', 'black')
     session.run('pip', 'install', '-e', '.')
@@ -34,7 +34,7 @@ def lint(session):
         'releasetool')
 
 
-@nox.session(python='3.6')
+@nox.session(python='3.8')
 def test(session):
     session.install('pytest')
     session.run('pip', 'install', '-e', '.')

--- a/releasetool/commands/tag/ruby.py
+++ b/releasetool/commands/tag/ruby.py
@@ -187,11 +187,12 @@ def kokoro_job_name(upstream_repo: str, package_name: str) -> Union[str, None]:
         The name of the Kokoro job to trigger or None if there is no job to trigger
     """
 
+    repo_name = upstream_repo.split("/")[-1]
     for name in RUBY_CLIENT_REPOS:
-        if name in upstream_repo:
+        if name == repo_name:
             return f"cloud-devrel/client-libraries/{name}/release"
     for name in RUBY_CLOUD_REPOS:
-        if name in upstream_repo:
+        if name == repo_name:
             return f"cloud-devrel/ruby/{name}/release"
 
     return f"cloud-devrel/client-libraries/{package_name}/release"

--- a/tests/commands/tag/test_tag_ruby.py
+++ b/tests/commands/tag/test_tag_ruby.py
@@ -46,6 +46,13 @@ def test_kokoro_job_name_apiary():
     assert job_name == "cloud-devrel/client-libraries/google-api-ruby-client/release"
 
 
+def test_kokoro_job_name_adapter():
+    job_name = kokoro_job_name(
+        "googleapis/ruby-spanner-activerecord", "ruby-spanner-activerecord"
+    )
+    assert job_name == "cloud-devrel/client-libraries/ruby-spanner-activerecord/release"
+
+
 def test_package_name():
     name = package_name({"head": {"ref": "release-storage-v1.2.3"}})
     assert name == "storage"


### PR DESCRIPTION
The ruby-spanner-activerecord release attempted to trigger a release of the ruby-spanner job because the name included `ruby-spanner`