### PR TITLE
fix(java): Specifying kokoro release job location for cloud java repositories

### DIFF
--- a/releasetool/commands/tag/java.py
+++ b/releasetool/commands/tag/java.py
@@ -37,7 +37,11 @@ def _parse_release_tag(output: str) -> str:
 """A list of repositories that have a different kokoro job location.
 """
 # Standard Java Framework repos in the GoogleCloudPlatform org
-java_framework_release_pool_repos: List[str] = ["google-cloud-spanner-hibernate", "spring-cloud-gcp", "cloud-spanner-r2dbc"]
+java_framework_release_pool_repos: List[str] = [
+    "google-cloud-spanner-hibernate",
+    "spring-cloud-gcp",
+    "cloud-spanner-r2dbc",
+]
 functions_framework_java_packages: List[str] = [
     "functions-framework-api",
     "java-function-invoker",

--- a/releasetool/commands/tag/java.py
+++ b/releasetool/commands/tag/java.py
@@ -37,7 +37,7 @@ def _parse_release_tag(output: str) -> str:
 """A list of repositories that have a different kokoro job location.
 """
 # Standard Java Framework repos in the GoogleCloudPlatform org
-java_framework_release_pool_repos: List[str] = ["google-cloud-spanner-hibernate"]
+java_framework_release_pool_repos: List[str] = ["google-cloud-spanner-hibernate", "spring-cloud-gcp", "cloud-spanner-r2dbc"]
 functions_framework_java_packages: List[str] = [
     "functions-framework-api",
     "java-function-invoker",


### PR DESCRIPTION
This PR specifies the kokoro release job location for [spring-cloud-gcp](https://github.com/GoogleCloudPlatform/spring-cloud-gcp) and [cloud-spanner-r2dbc](https://github.com/GoogleCloudPlatform/cloud-spanner-r2dbc).
This is a part of migrating the release process for these repos to release-please+release-trigger automation.