### PR TITLE
fix: skip entire tag workflow for languages not in the allowlist

### DIFF
--- a/releasetool/filehelpers.py
+++ b/releasetool/filehelpers.py
@@ -33,7 +33,6 @@ def open_editor(filename: str, return_contents: bool = False) -> Optional[str]:
 def open_editor_with_content(
     filename: str, contents: str, return_contents: bool = False
 ) -> Optional[str]:
-
     with open(filename, "w") as fh:
         fh.write(contents)
 

--- a/tests/test_autorelease_tag.py
+++ b/tests/test_autorelease_tag.py
@@ -65,6 +65,7 @@ def test_run_releasetool_tag_delegates(tag_mock):
     assert ctx == context
 
 
+@patch("autorelease.tag.LANGUAGE_ALLOWLIST", ["java"])
 @patch("autorelease.tag.run_releasetool_tag")
 def test_process_issue_skips_non_merged(run_releasetool_tag):
     github = Mock()


### PR DESCRIPTION
Previously, for repositories whose language was not in the allowlist, we would only skip the actual tagging logic, but would still try to remove labels. After this change, we will also only attempt to remove labels if the language is in the allowlist.