### PR TITLE
feat: cpp support

### DIFF
--- a/autorelease/__main__.py
+++ b/autorelease/__main__.py
@@ -47,6 +47,8 @@ def main():
         "--kokoro-credentials", default=os.environ.get("AUTORELEASE_KOKORO_CREDENTIALS")
     )
     parser.add_argument("--pull", default=None)
+    parser.add_argument("--release", default=None)
+    parser.add_argument("--lang", default=None)
     parser.add_argument("command")
     parser.add_argument("--multi-scm-name")
 
@@ -75,14 +77,25 @@ def main():
         else:
             return
     elif args.command == "trigger-single":
+        if args.release:
+            if not args.lang:
+                raise Exception("missing required arg --lang")
+            report = trigger.trigger_for_release(
+                args.github_token,
+                args.kokoro_credentials,
+                args.release,
+                trigger.to_pysafe_language_name(args.lang),
+                args.multi_scm_name,
+            )
         if not args.pull:
             raise Exception("missing required arg --pull")
-        report = trigger.trigger_single(
-            args.github_token,
-            args.kokoro_credentials,
-            args.pull,
-            multi_scm_name=args.multi_scm_name,
-        )
+        else:
+            report = trigger.trigger_single(
+                args.github_token,
+                args.kokoro_credentials,
+                args.pull,
+                multi_scm_name=args.multi_scm_name,
+            )
 
         if args.report:
             report.write(args.report)

--- a/releasetool/commands/tag/cpp.py
+++ b/releasetool/commands/tag/cpp.py
@@ -1,0 +1,32 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Union
+
+
+def kokoro_job_name(upstream_repo: str, package_name: str) -> Union[str, None]:
+    """Return the Kokoro job name.
+
+    Args:
+        upstream_repo (str): The GitHub repo in the form of `<owner>/<repo>`
+        package_name (str): The name of package to release
+
+    Returns:
+        The name of the Kokoro job to trigger or None if there is no job to trigger
+    """
+    return f"cloud-devrel/client-libraries/cpp/{upstream_repo.rsplit('/', 1)[-1]}/release/publish"
+
+
+def package_name(pull: dict) -> Union[str, None]:
+    return None

--- a/tests/commands/tag/test_tag_cpp.py
+++ b/tests/commands/tag/test_tag_cpp.py
@@ -1,0 +1,25 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from releasetool.commands.tag.cpp import kokoro_job_name, package_name
+
+
+def test_kokoro_job_name():
+    job_name = kokoro_job_name("upstream-owner/upstream-repo", "some-package-name")
+    assert job_name == "cloud-devrel/client-libraries/cpp/upstream-repo/release/publish"
+
+
+def test_package_name():
+    name = package_name({"head": {"ref": "release-storage-v1.2.3"}})
+    assert name is None

--- a/tests/test_autorelease_trigger.py
+++ b/tests/test_autorelease_trigger.py
@@ -216,19 +216,20 @@ def test_trigger_single(
     )
     update_pull_labels.assert_not_called()
 
+
 @patch("autorelease.kokoro.make_authorized_session")
 @patch("autorelease.github.GitHub.get_url")
 @patch("autorelease.kokoro.trigger_build")
-def test_trigger_for_release(
-    trigger_build, get_url, make_authorized_session
-):
+def test_trigger_for_release(trigger_build, get_url, make_authorized_session):
     kokoro_session = Mock()
     make_authorized_session.return_value = kokoro_session
     get_url.return_value = {
         "sha": "abcd1234",
     }
 
-    release_url = "https://api.github.com/googleapis/google-cloud-cpp/releases/tag/v2.9.1"
+    release_url = (
+        "https://api.github.com/googleapis/google-cloud-cpp/releases/tag/v2.9.1"
+    )
     reporter = trigger.trigger_for_release(
         "fake-github-token", "fake-kokoro-credentials", release_url, "cpp"
     )
@@ -241,7 +242,6 @@ def test_trigger_for_release(
         env_vars={},
         multi_scm_name="",
     )
-
 
 
 @patch("autorelease.trigger.LANGUAGE_ALLOWLIST", ["java"])

--- a/tests/test_autorelease_trigger.py
+++ b/tests/test_autorelease_trigger.py
@@ -216,6 +216,33 @@ def test_trigger_single(
     )
     update_pull_labels.assert_not_called()
 
+@patch("autorelease.kokoro.make_authorized_session")
+@patch("autorelease.github.GitHub.get_url")
+@patch("autorelease.kokoro.trigger_build")
+def test_trigger_for_release(
+    trigger_build, get_url, make_authorized_session
+):
+    kokoro_session = Mock()
+    make_authorized_session.return_value = kokoro_session
+    get_url.return_value = {
+        "sha": "abcd1234",
+    }
+
+    release_url = "https://api.github.com/googleapis/google-cloud-cpp/releases/tag/v2.9.1"
+    reporter = trigger.trigger_for_release(
+        "fake-github-token", "fake-kokoro-credentials", release_url, "cpp"
+    )
+
+    assert len(reporter.results) == 1
+    trigger_build.assert_called_with(
+        kokoro_session,
+        job_name="cloud-devrel/client-libraries/cpp/google-cloud-cpp/release/publish",
+        sha="abcd1234",
+        env_vars={},
+        multi_scm_name="",
+    )
+
+
 
 @patch("autorelease.trigger.LANGUAGE_ALLOWLIST", ["java"])
 @patch("autorelease.kokoro.make_authorized_session")


### PR DESCRIPTION
New variation on the trigger-single command:
--release: the github release uri
--lang: the language, so we don't have to guess