### PR TITLE
feat: Remove Ruby from Kokoro tagger

### DIFF
--- a/autorelease/tag.py
+++ b/autorelease/tag.py
@@ -22,7 +22,6 @@ import releasetool.github
 
 LANGUAGE_ALLOWLIST = [
     "dotnet",
-    "ruby",
 ]
 
 


### PR DESCRIPTION
Ruby is migrating off of the Kokoro-based release tagger and trigger, and adopting the GitHub App bots. (See, e.g. https://github.com/googleapis/google-cloud-ruby/pull/21575 and corresponding pull requests across all Ruby repos.)

Please coordinate with @dazuma for merging. We want this merged and released about the same time as the corresponding Ruby repo PRs are merged.