### PR TITLE
fix: update kokoro release job name for google-cloudevents-ruby

### DIFF
--- a/releasetool/commands/tag/ruby.py
+++ b/releasetool/commands/tag/ruby.py
@@ -34,6 +34,7 @@ RUBY_CLIENT_REPOS = [
     "google-api-ruby-client",
     "google-auth-library-ruby",
     "google-cloud-ruby",
+    "google-cloudevents-ruby",
     "ruby-cloud-env",
     "ruby-spanner",
     "ruby-spanner-activerecord",
@@ -46,7 +47,6 @@ RUBY_CLOUD_REPOS = [
     "appengine-ruby",
     "functions-framework-ruby",
     "serverless-exec-ruby",
-    "google-cloudevents-ruby",
 ]
 
 # Standard Ruby monorepos with gems located in subdirectories


### PR DESCRIPTION
Switches the kokoro release job for google-cloudevents-ruby from one located in the `cloud-devrel/ruby` directory to one located `cloud-devrel/client-libraries` directory. (The kokoro configs have already been duplicated into the new location.) This move is an attempt to provide the correct GitHub credentials for the release job to update the release pull request. The client-libraries directory has access to resources for repositories under the googleapis org, resources that seem not to be available to other subdirectories of cloud-devrel.