### PR TITLE
fix: update fusion url to fusion2

### DIFF
--- a/releasetool/commands/common.py
+++ b/releasetool/commands/common.py
@@ -169,7 +169,7 @@ def release_exists(ctx: TagContext) -> bool:
 
 
 def publish_via_kokoro(ctx: TagContext) -> None:
-    kokoro_url = "https://fusion.corp.google.com/projectanalysis/current/KOKORO/"
+    kokoro_url = "https://fusion2.corp.google.com/ci;prev=s/kokoro/"
 
     ctx.fusion_url = parse.urljoin(
         kokoro_url, parse.quote_plus(f"prod:{ctx.kokoro_job_name}")

--- a/releasetool/commands/common.py
+++ b/releasetool/commands/common.py
@@ -169,11 +169,8 @@ def release_exists(ctx: TagContext) -> bool:
 
 
 def publish_via_kokoro(ctx: TagContext) -> None:
-    kokoro_url = "https://fusion2.corp.google.com/ci;prev=s/kokoro/"
-
-    ctx.fusion_url = parse.urljoin(
-        kokoro_url, parse.quote_plus(f"prod:{ctx.kokoro_job_name}")
-    )
+    kokoro_url = "https://fusion2.corp.google.com/ci;prev=s/kokoro/prod"
+    ctx.fusion_url = f"${kokoro_url}:${parse.quote_plus(ctx.kokoro_job_name)}"
 
     if ctx.interactive:
         pyperclip.copy(ctx.release_tag)


### PR DESCRIPTION
Example: `https://fusion.corp.google.com/projectanalysis/current/KOKORO/prod%3Afoo%2Fbar%2Fautorelease` -> `https://fusion2.corp.google.com/ci;prev=s/kokoro/prod:foo%2Fbar%2Fautorelease`