### PR TITLE
fix: avoid tag failures for .NET on empty PR bodies

### DIFF
--- a/releasetool/commands/tag/dotnet.py
+++ b/releasetool/commands/tag/dotnet.py
@@ -50,7 +50,7 @@ def create_releases(ctx: TagContext) -> None:
 
     commitish = ctx.release_pr["merge_commit_sha"]
     title = ctx.release_pr["title"]
-    body_lines = ctx.release_pr["body"].splitlines()
+    body_lines = (ctx.release_pr["body"] or "").splitlines()
     all_lines = [title] + body_lines
     pr_comment = ""
     for line in all_lines:


### PR DESCRIPTION
This isn't an issue for normal automated releases, but has bitten us in the past when creating release PRs manually.

Fixes b/345375783