### PR TITLE
feat: support ruby-core-libraries repository

### DIFF
--- a/releasetool/commands/tag/ruby.py
+++ b/releasetool/commands/tag/ruby.py
@@ -37,6 +37,7 @@ RUBY_CLIENT_REPOS = [
     "google-cloudevents-ruby",
     "opentelemetry-operations-ruby",
     "ruby-cloud-env",
+    "ruby-core-libraries",
     "ruby-spanner",
     "ruby-spanner-activerecord",
     "ruby-style",
@@ -57,6 +58,7 @@ RUBY_MONO_REPOS = [
     "gapic-generator-ruby",
     "google-api-ruby-client",
     "google-cloud-ruby",
+    "ruby-core-libraries",
     "ruby-spanner",
 ]
 


### PR DESCRIPTION
Add the ruby-core-libraries github repository to the configuration so release triggering knows how to find the release kokoro job.