### PR TITLE
feat(autorelease): automatically assume multiScm for node and python

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -17,7 +17,7 @@ import pathlib
 
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
-ALL_PYTHON = ["3.8", "3.9", "3.10", "3.11", "3.12"]
+ALL_PYTHON = ["3.9", "3.10", "3.11", "3.12"]
 
 @nox.session(python='3.8')
 def blacken(session):


### PR DESCRIPTION
For the languages that fully migrated to shared internal scripts, assume a multiScm name that is the repo name.

This makes it so every repository will not need to update the release-trigger.yml to set multiScmName.