### PR TITLE
feat: Support releasing .NET from the Cloud SDK Windows Kokoro Instance.

### DIFF
--- a/releasetool/commands/tag/dotnet.py
+++ b/releasetool/commands/tag/dotnet.py
@@ -108,6 +108,10 @@ def kokoro_job_name(upstream_repo: str, package_name: str) -> Union[str, None]:
         return (
             f"cloud-libraries-dotnet/{repo_short_name}/gcp_windows_docker/autorelease"
         )
+    else if repo_short_name == "google-cloudevents-dotnet":
+         return (
+            f"cloud-libraries-dotnet/{repo_short_name}/rbe_windows_releases/autorelease"
+        )
     else:
         return f"cloud-sharp/{repo_short_name}/gcp_windows/autorelease"
 

--- a/releasetool/commands/tag/dotnet.py
+++ b/releasetool/commands/tag/dotnet.py
@@ -108,7 +108,7 @@ def kokoro_job_name(upstream_repo: str, package_name: str) -> Union[str, None]:
         return (
             f"cloud-libraries-dotnet/{repo_short_name}/gcp_windows_docker/autorelease"
         )
-    else if repo_short_name == "google-cloudevents-dotnet":
+    elif repo_short_name == "google-cloudevents-dotnet":
          return (
             f"cloud-libraries-dotnet/{repo_short_name}/rbe_windows_releases/autorelease"
         )

--- a/releasetool/commands/tag/dotnet.py
+++ b/releasetool/commands/tag/dotnet.py
@@ -109,7 +109,7 @@ def kokoro_job_name(upstream_repo: str, package_name: str) -> Union[str, None]:
             f"cloud-libraries-dotnet/{repo_short_name}/gcp_windows_docker/autorelease"
         )
     elif repo_short_name == "google-cloudevents-dotnet":
-         return (
+        return (
             f"cloud-libraries-dotnet/{repo_short_name}/rbe_windows_releases/autorelease"
         )
     else:


### PR DESCRIPTION
We now have:

- Spanner EF from the new CI in Docker Pools
- Cloud Events from the new CI in Instance Pools, which is MOSS compliant.
- Everything else on old CI.

Once we have Instance Pools working, I'll migrate Spanner EF there and then everything else.