### PR TITLE
chore: Remove dotnet from language allowlist

### DIFF
--- a/autorelease/tag.py
+++ b/autorelease/tag.py
@@ -20,16 +20,11 @@ from autorelease import common, github, kokoro, reporter
 from releasetool.commands.common import TagContext
 import releasetool.github
 
-LANGUAGE_ALLOWLIST = [
-    "dotnet",
-]
+LANGUAGE_ALLOWLIST = []
 
 # This is only used in the autorelease/tag workflows.
 # Direct, explicit triggering on repos in this list is still possible.
-REPO_DENYLIST = [
-    "googleapis/google-cloudevents-dotnet",
-    "googleapis/dotnet-spanner-entity-framework",
-]
+REPO_DENYLIST = []
 
 
 ORGANIZATIONS_TO_SCAN = ["googleapis", "GoogleCloudPlatform"]


### PR DESCRIPTION
Remove `dotnet` from language allowlist as release-please is now doing the tagging and all repos under dotnet have been migrated to use this. Since we are doing this, we no longer need the explicit deny list for individual repos.