### PR TITLE
ci: remove unused secrets from kokoro config

### DIFF
--- a/.kokoro-autorelease/common.cfg
+++ b/.kokoro-autorelease/common.cfg
@@ -51,14 +51,6 @@ before_action {
 
 # GitHub token for yoshi-automation
 # TODO(busunkim): Remove this key once KMS setup is complete.
-before_action {
-  fetch_keystore {
-    keystore_resource {
-      keystore_config_id: 73713
-      keyname: "yoshi-automation-github-key"
-    }
-  }
-}
 
 # Magic GitHub Proxy API
 before_action {


### PR DESCRIPTION
Removing yoshi-automation-github-key from Kokoro configurations as it is no longer needed.

b/510338703